### PR TITLE
Rethrows the exception when restoring the storage

### DIFF
--- a/packages/reown_core/lib/store/generic_store.dart
+++ b/packages/reown_core/lib/store/generic_store.dart
@@ -158,6 +158,7 @@ class GenericStore<T> implements IGenericStore<T> {
       } catch (e) {
         // print('Error restoring $storageKey: $e');
         await storage.delete(storedVersion);
+        rethrow;
       }
     }
   }


### PR DESCRIPTION
# Description

When `fromJson` fails to parse the value, exceptions are hidden through the try-catch, so the user is unaware.

~Possibly handle #12~

## How Has This Been Tested?

Throw exceptions in `fromJson` should be able to reproduce the issue.