### PR TITLE
fix: `generic_store` does not set the `version` field after reconnecting wallet

### DIFF
--- a/packages/reown_core/lib/store/generic_store.dart
+++ b/packages/reown_core/lib/store/generic_store.dart
@@ -124,6 +124,7 @@ class GenericStore<T> implements IGenericStore<T> {
     );
 
     await storage.set(storageKey, data);
+    await updateVersion();
   }
 
   @override
@@ -131,7 +132,7 @@ class GenericStore<T> implements IGenericStore<T> {
     // If we haven't stored our version yet, we need to store it and stop
     if (!storage.has(context)) {
       // print('Storing $context');
-      await storage.set(context, {'version': version});
+      await updateVersion();
       await storage.set(storageKey, <String, dynamic>{});
       return;
     }
@@ -142,7 +143,7 @@ class GenericStore<T> implements IGenericStore<T> {
     if (storedVersion != version) {
       // print('Updating storage from $storedVersion to $version');
       await storage.delete('$storedVersion//$context');
-      await storage.set(context, {'version': version});
+      await updateVersion();
       await storage.set(storageKey, <String, dynamic>{});
       return;
     }
@@ -169,4 +170,10 @@ class GenericStore<T> implements IGenericStore<T> {
       throw Errors.getInternalError(Errors.NOT_INITIALIZED);
     }
   }
+
+  @protected
+  Future<void> updateVersion() async {
+    await storage.set(context, {'version': version});
+  }
+
 }


### PR DESCRIPTION

# Description
When you first start the app, the `version` field will be set here: https://github.com/reown-com/reown_flutter/blob/1f043e83e57d0a9e3ad7cffdc46b7907c07711cf/packages/reown_core/lib/store/generic_store.dart#L132-L137
But once the wallet is disconnected, this field will be removed in this method https://github.com/reown-com/reown_flutter/blob/1f043e83e57d0a9e3ad7cffdc46b7907c07711cf/packages/reown_core/lib/store/shared_prefs_store.dart#L116-L124
and will never be set until the next time the store is initialized, i.e. until the next time you open the app. This means that this condition will never be true after the next restart of the app
https://github.com/reown-com/reown_flutter/blob/1f043e83e57d0a9e3ad7cffdc46b7907c07711cf/packages/reown_core/lib/store/generic_store.dart#L132

My fix is to just set the version every time the `persist` method in `generic_store` is called. I'm not familiar with the rest of the codebase, so there may be a better place to update the version, perhaps here when the session is saved after logging in
https://github.com/reown-com/reown_flutter/blob/1f043e83e57d0a9e3ad7cffdc46b7907c07711cf/packages/reown_appkit/lib/modal/appkit_modal_impl.dart#L403-L419

<!--
Please include:
* summary of the changes and the related issue
* relevant motivation and context
-->

Resolves #[12](https://github.com/reown-com/reown_flutter/issues/12)

## How Has This Been Tested?

<!--
Please:
* describe the tests that you ran to verify your changes.
* provide instructions so we can reproduce.
-->

If you follow these steps in the appkit/modal example, the session will not be persisted

1. Connect any wallet.
2. Disconnect.
3. Connect any wallet again.
4. Restart the application / do a hot restart

<!-- If valid for smoke test on feature add screenshots -->

## Due Dilligence

* [ ] Breaking change
* [ ] Requires a documentation update