### PR TITLE
🐛 Replace single - subscription stream in _channel creation with broadcast stream

### DIFF
--- a/packages/reown_core/lib/relay_client/websocket/websocket_handler.dart
+++ b/packages/reown_core/lib/relay_client/websocket/websocket_handler.dart
@@ -1,8 +1,8 @@
 import 'dart:async';
 
-import 'package:stream_channel/stream_channel.dart';
-import 'package:reown_core/relay_client/websocket/i_websocket_handler.dart';
 import 'package:reown_core/models/basic_models.dart';
+import 'package:reown_core/relay_client/websocket/i_websocket_handler.dart';
+import 'package:stream_channel/stream_channel.dart';
 import 'package:web_socket_channel/web_socket_channel.dart';
 
 class WebSocketHandler implements IWebSocketHandler {
@@ -51,8 +51,10 @@ class WebSocketHandler implements IWebSocketHandler {
       );
     }
 
-    _channel = _socket!.cast<String>();
-
+    _channel = StreamChannel(
+      _socket!.stream.asBroadcastStream().cast(),
+      StreamController.broadcast(sync: true)..stream.cast().pipe(_socket!.sink),
+    );
     if (_channel == null) {
       // print('Socket channel is null, waiting...');
       await Future.delayed(const Duration(milliseconds: 500));


### PR DESCRIPTION
Due to `_channel = _socket!.cast<String>()`, the `_channel` will be assigned to CloseGuaranteeChannel. Inside the listen method of `CloseGuaranteeChannel`, there is a line of code:
```dart
var subscription = _inner.listen(onData,
        onError: onError, onDone: onDone, cancelOnError: cancelOnError);
```
When this _inner.listen method is called multiple times, it will also throw the `Bad state: Stream has already been listened to error`.