### PR TITLE
fix(ReownAppKitModal): Clean up corresponding singleton on dispose

### DIFF
--- a/packages/reown_appkit/lib/modal/appkit_modal_impl.dart
+++ b/packages/reown_appkit/lib/modal/appkit_modal_impl.dart
@@ -114,6 +114,7 @@ class ReownAppKitModal
   @override
   final balanceNotifier = ValueNotifier<String>('-.--');
 
+  bool _isDisposed = false;
   bool _isOpen = false;
   @override
   bool get isOpen => _isOpen;
@@ -253,23 +254,11 @@ class ReownAppKitModal
     );
   }
 
-  T _registerSingleton<T extends Object>(T Function() factoryFunc) {
-    final type = T;
-    return GetIt.I.registerSingleton<T>(
-      factoryFunc(),
-      instanceName: type.toString(),
-    );
-  }
+  T _registerSingleton<T extends Object>(T Function() factoryFunc) => GetIt.I.registerSingletonIfAbsent<T>(factoryFunc);
 
-  T _getSingleton<T extends Object>() {
-    final type = T;
-    return GetIt.I<T>(instanceName: type.toString());
-  }
+  T _getSingleton<T extends Object>() => GetIt.I<T>();
 
-  FutureOr _unregisterSingleton<T extends Object>() {
-    final type = T;
-    return GetIt.I.unregister<T>(instanceName: type.toString());
-  }
+  FutureOr _unregisterSingleton<T extends Object>() => GetIt.I.unregister<T>();
 
   IMagicService get _magicService => _getSingleton<IMagicService>();
   ICoinbaseService get _coinbaseService => _getSingleton<ICoinbaseService>();
@@ -1440,19 +1429,20 @@ class ReownAppKitModal
       _lastChainEmitted = null;
       _supportsOneClickAuth = false;
       _status = ReownAppKitModalStatus.idle;
-      _unregisterSingleton<UriService>();
-      _unregisterSingleton<AnalyticsService>();
-      _unregisterSingleton<ExplorerService>();
-      _unregisterSingleton<NetworkService>();
-      _unregisterSingleton<ToastService>();
-      _unregisterSingleton<BlockChainService>();
-      _unregisterSingleton<MagicService>();
-      _unregisterSingleton<CoinbaseService>();
-      _unregisterSingleton<PhantomService>();
-      _unregisterSingleton<SiweService>();
+      _unregisterSingleton<IUriService>();
+      _unregisterSingleton<IAnalyticsService>();
+      _unregisterSingleton<IExplorerService>();
+      _unregisterSingleton<INetworkService>();
+      _unregisterSingleton<IToastService>();
+      _unregisterSingleton<IBlockChainService>();
+      _unregisterSingleton<IMagicService>();
+      _unregisterSingleton<ICoinbaseService>();
+      _unregisterSingleton<IPhantomService>();
+      _unregisterSingleton<ISiweService>();
       await Future.delayed(Duration(milliseconds: 500));
       _notify();
     }
+    _isDisposed = true;
     super.dispose();
   }
 
@@ -1482,7 +1472,11 @@ class ReownAppKitModal
 
   ////////* PRIVATE METHODS */////////
 
-  void _notify() => notifyListeners();
+  void _notify() {
+    if (!_isDisposed) {
+      notifyListeners();
+    }
+  }
 
   bool get _initializeCoinbaseSDK {
     final cbId = CoinbaseUtils.defaultListingData.id;

--- a/packages/reown_appkit/lib/modal/appkit_modal_impl.dart
+++ b/packages/reown_appkit/lib/modal/appkit_modal_impl.dart
@@ -194,10 +194,10 @@ class ReownAppKitModal
     _setRequiredNamespaces(requiredNamespaces);
     _setOptionalNamespaces(optionalNamespaces);
 
-    GetIt.I.registerSingletonIfAbsent<IUriService>(
+    _registerSingleton<IUriService>(
       () => UriService(core: _appKit.core),
     );
-    GetIt.I.registerSingletonIfAbsent<IAnalyticsService>(
+    _registerSingleton<IAnalyticsService>(
       () => AnalyticsService(
         core: _appKit.core,
         enableAnalytics: enableAnalytics,
@@ -207,7 +207,7 @@ class ReownAppKitModal
     _analyticsService.init().then(
           (_) => _analyticsService.sendEvent(ModalLoadedEvent()),
         );
-    GetIt.I.registerSingletonIfAbsent<IExplorerService>(
+    _registerSingleton<IExplorerService>(
       () => ExplorerService(
         core: _appKit.core,
         referer: _appKit.metadata.name.replaceAll(' ', ''),
@@ -217,40 +217,53 @@ class ReownAppKitModal
         namespaces: {..._requiredNamespaces, ..._optionalNamespaces},
       ),
     );
-    GetIt.I.registerSingletonIfAbsent<INetworkService>(() => NetworkService());
-    GetIt.I.registerSingletonIfAbsent<IToastService>(() => ToastService());
-    GetIt.I.registerSingletonIfAbsent<IBlockChainService>(
+    _registerSingleton<INetworkService>(() => NetworkService());
+    _registerSingleton<IToastService>(() => ToastService());
+    _registerSingleton<IBlockChainService>(
       () => BlockChainService(
         core: _appKit.core,
       ),
     );
-    GetIt.I.registerSingletonIfAbsent<IMagicService>(
+    _registerSingleton<IMagicService>(
       () => MagicService(
         core: _appKit.core,
         metadata: _appKit.metadata,
         featuresConfig: this.featuresConfig,
       ),
     );
-    GetIt.I.registerSingletonIfAbsent<ICoinbaseService>(
+    _registerSingleton<ICoinbaseService>(
       () => CoinbaseService(
         core: _appKit.core,
         metadata: _appKit.metadata,
         enabled: _initializeCoinbaseSDK,
       ),
     );
-    GetIt.I.registerSingletonIfAbsent<IPhantomService>(
+    _registerSingleton<IPhantomService>(
       () => PhantomService(
         core: _appKit.core,
         metadata: _appKit.metadata,
       ),
     );
-    GetIt.I.registerSingletonIfAbsent<ISiweService>(
+    _registerSingleton<ISiweService>(
       () => SiweService(
         appKit: _appKit,
         siweConfig: siweConfig,
         namespaces: {..._requiredNamespaces, ..._optionalNamespaces},
       ),
     );
+  }
+
+  T _registerSingleton<T extends Object>(T Function() factoryFunc) {
+    final type = T;
+    return GetIt.I.registerSingleton<T>(
+      factoryFunc(),
+      instanceName: type.toString(),
+    );
+  }
+
+  FutureOr _unregisterSingleton<T extends Object>() {
+    final type = T;
+    return GetIt.I.unregister<T>(instanceName: type.toString());
   }
 
   IMagicService get _magicService => GetIt.I<IMagicService>();
@@ -1422,6 +1435,16 @@ class ReownAppKitModal
       _lastChainEmitted = null;
       _supportsOneClickAuth = false;
       _status = ReownAppKitModalStatus.idle;
+      _unregisterSingleton<UriService>();
+      _unregisterSingleton<AnalyticsService>();
+      _unregisterSingleton<ExplorerService>();
+      _unregisterSingleton<NetworkService>();
+      _unregisterSingleton<ToastService>();
+      _unregisterSingleton<BlockChainService>();
+      _unregisterSingleton<MagicService>();
+      _unregisterSingleton<CoinbaseService>();
+      _unregisterSingleton<PhantomService>();
+      _unregisterSingleton<SiweService>();
       await Future.delayed(Duration(milliseconds: 500));
       _notify();
     }

--- a/packages/reown_appkit/lib/modal/appkit_modal_impl.dart
+++ b/packages/reown_appkit/lib/modal/appkit_modal_impl.dart
@@ -261,22 +261,27 @@ class ReownAppKitModal
     );
   }
 
+  T _getSingleton<T extends Object>() {
+    final type = T;
+    return GetIt.I<T>(instanceName: type.toString());
+  }
+
   FutureOr _unregisterSingleton<T extends Object>() {
     final type = T;
     return GetIt.I.unregister<T>(instanceName: type.toString());
   }
 
-  IMagicService get _magicService => GetIt.I<IMagicService>();
-  ICoinbaseService get _coinbaseService => GetIt.I<ICoinbaseService>();
-  IPhantomService get _phantomService => GetIt.I<IPhantomService>();
+  IMagicService get _magicService => _getSingleton<IMagicService>();
+  ICoinbaseService get _coinbaseService => _getSingleton<ICoinbaseService>();
+  IPhantomService get _phantomService => _getSingleton<IPhantomService>();
 
-  IUriService get _uriService => GetIt.I<IUriService>();
-  IToastService get _toastService => GetIt.I<IToastService>();
-  IAnalyticsService get _analyticsService => GetIt.I<IAnalyticsService>();
-  IExplorerService get _explorerService => GetIt.I<IExplorerService>();
-  INetworkService get _networkService => GetIt.I<INetworkService>();
-  IBlockChainService get _blockchainService => GetIt.I<IBlockChainService>();
-  ISiweService get _siweService => GetIt.I<ISiweService>();
+  IUriService get _uriService => _getSingleton<IUriService>();
+  IToastService get _toastService => _getSingleton<IToastService>();
+  IAnalyticsService get _analyticsService => _getSingleton<IAnalyticsService>();
+  IExplorerService get _explorerService => _getSingleton<IExplorerService>();
+  INetworkService get _networkService => _getSingleton<INetworkService>();
+  IBlockChainService get _blockchainService => _getSingleton<IBlockChainService>();
+  ISiweService get _siweService => _getSingleton<ISiweService>();
 
   ////////* PUBLIC METHODS */////////
 


### PR DESCRIPTION
This PR aims to discuss this #97 . When the network is poor, if an error occurs during `init` method of `ReownAppKitModal`, such as the situation described in #66 , the _status property within `ReownAppKitModal` will be set to `ReownAppKitModalStatus.error`. In this case, the instance will no longer be able to recover, and it cannot be re-instantiated either, because calling the `init` method twice will throw an error.

However, cleaning up the corresponding singleton during the `dispose` can ensure that ReownAppKitModal can be re - instantiated.