### PR TITLE
[WalletKit] Added `wallet_addEthereumChain` capability on sample Wallet.

### DIFF
--- a/packages/reown_appkit/example/base/ios/Podfile.lock
+++ b/packages/reown_appkit/example/base/ios/Podfile.lock
@@ -66,18 +66,18 @@ EXTERNAL SOURCES:
     :path: ".symlinks/plugins/webview_flutter_wkwebview/darwin"
 
 SPEC CHECKSUMS:
-  appcheck: e1ab9d4e03736f03e0401554a134d1ed502d7629
-  coinbase_wallet_sdk: 7ccd4e1a7940deba6ba9bd81beece999a2268c15
+  appcheck: f3c430f928f9c69ccd8b5d4df04766ac0e57c9aa
+  coinbase_wallet_sdk: c893738400ef78bd20e7f4195cbb38266f7d15e8
   CoinbaseWalletSDK: ea1f37512bbc69ebe07416e3b29bf840f5cc3152
-  connectivity_plus: 2a701ffec2c0ae28a48cf7540e279787e77c447d
+  connectivity_plus: cb623214f4e1f6ef8fe7403d580fdad517d2f7dd
   Flutter: e0871f40cf51350855a761d2e70bf5af5b9b5de7
-  package_info_plus: c0502532a26c7662a62a356cebe2692ec5fe4ec4
-  path_provider_foundation: 2b6b4c569c0fb62ec74538f866245ac84301af46
-  shared_preferences_foundation: fcdcbc04712aee1108ac7fda236f363274528f78
-  sqflite_darwin: 5a7236e3b501866c1c9befc6771dfd73ffb8702d
-  url_launcher_ios: 5334b05cef931de560670eeae103fd3e431ac3fe
-  webview_flutter_wkwebview: 0982481e3d9c78fd5c6f62a002fcd24fc791f1e4
+  package_info_plus: af8e2ca6888548050f16fa2f1938db7b5a5df499
+  path_provider_foundation: 080d55be775b7414fd5a5ef3ac137b97b097e564
+  shared_preferences_foundation: 9e1978ff2562383bd5676f64ec4e9aa8fa06a6f7
+  sqflite_darwin: 20b2a3a3b70e43edae938624ce550a3cbf66a3d0
+  url_launcher_ios: 694010445543906933d732453a59da0a173ae33d
+  webview_flutter_wkwebview: 44d4dee7d7056d5ad185d25b38404436d56c547c
 
 PODFILE CHECKSUM: 0772a2bd8cd4c7aaeb2576ddfaf6b03be722593b
 
-COCOAPODS: 1.15.2
+COCOAPODS: 1.16.2

--- a/packages/reown_appkit/example/modal/ios/Podfile.lock
+++ b/packages/reown_appkit/example/modal/ios/Podfile.lock
@@ -71,19 +71,19 @@ EXTERNAL SOURCES:
     :path: ".symlinks/plugins/webview_flutter_wkwebview/darwin"
 
 SPEC CHECKSUMS:
-  appcheck: e1ab9d4e03736f03e0401554a134d1ed502d7629
-  coinbase_wallet_sdk: 7ccd4e1a7940deba6ba9bd81beece999a2268c15
+  appcheck: f3c430f928f9c69ccd8b5d4df04766ac0e57c9aa
+  coinbase_wallet_sdk: c893738400ef78bd20e7f4195cbb38266f7d15e8
   CoinbaseWalletSDK: ea1f37512bbc69ebe07416e3b29bf840f5cc3152
-  connectivity_plus: 2a701ffec2c0ae28a48cf7540e279787e77c447d
+  connectivity_plus: cb623214f4e1f6ef8fe7403d580fdad517d2f7dd
   Flutter: e0871f40cf51350855a761d2e70bf5af5b9b5de7
-  integration_test: 252f60fa39af5e17c3aa9899d35d908a0721b573
-  package_info_plus: c0502532a26c7662a62a356cebe2692ec5fe4ec4
-  path_provider_foundation: 2b6b4c569c0fb62ec74538f866245ac84301af46
-  shared_preferences_foundation: fcdcbc04712aee1108ac7fda236f363274528f78
-  sqflite_darwin: 5a7236e3b501866c1c9befc6771dfd73ffb8702d
-  url_launcher_ios: 5334b05cef931de560670eeae103fd3e431ac3fe
-  webview_flutter_wkwebview: 0982481e3d9c78fd5c6f62a002fcd24fc791f1e4
+  integration_test: 4a889634ef21a45d28d50d622cf412dc6d9f586e
+  package_info_plus: af8e2ca6888548050f16fa2f1938db7b5a5df499
+  path_provider_foundation: 080d55be775b7414fd5a5ef3ac137b97b097e564
+  shared_preferences_foundation: 9e1978ff2562383bd5676f64ec4e9aa8fa06a6f7
+  sqflite_darwin: 20b2a3a3b70e43edae938624ce550a3cbf66a3d0
+  url_launcher_ios: 694010445543906933d732453a59da0a173ae33d
+  webview_flutter_wkwebview: 44d4dee7d7056d5ad185d25b38404436d56c547c
 
 PODFILE CHECKSUM: 0a7d5b7d0e53420cb0284f7b2f171f93843b94d2
 
-COCOAPODS: 1.15.2
+COCOAPODS: 1.16.2

--- a/packages/reown_walletkit/example/ios/Podfile.lock
+++ b/packages/reown_walletkit/example/ios/Podfile.lock
@@ -47,15 +47,15 @@ EXTERNAL SOURCES:
     :path: ".symlinks/plugins/url_launcher_ios/ios"
 
 SPEC CHECKSUMS:
-  connectivity_plus: 18382e7311ba19efcaee94442b23b32507b20695
+  connectivity_plus: 2256d3e20624a7749ed21653aafe291a46446fee
   Flutter: e0871f40cf51350855a761d2e70bf5af5b9b5de7
   MTBBarcodeScanner: f453b33c4b7dfe545d8c6484ed744d55671788cb
-  package_info_plus: c0502532a26c7662a62a356cebe2692ec5fe4ec4
-  qr_bar_code_scanner_dialog: d59c27f37c96ef8649711e6eee8033a69191f907
-  qr_code_scanner: bb67d64904c3b9658ada8c402e8b4d406d5d796e
-  shared_preferences_foundation: fcdcbc04712aee1108ac7fda236f363274528f78
-  url_launcher_ios: 5334b05cef931de560670eeae103fd3e431ac3fe
+  package_info_plus: af8e2ca6888548050f16fa2f1938db7b5a5df499
+  qr_bar_code_scanner_dialog: a4cb7ad7201cbf8b888f3e6e58972b611ac43b28
+  qr_code_scanner: d77f94ecc9abf96d9b9b8fc04ef13f611e5a147a
+  shared_preferences_foundation: 9e1978ff2562383bd5676f64ec4e9aa8fa06a6f7
+  url_launcher_ios: 694010445543906933d732453a59da0a173ae33d
 
 PODFILE CHECKSUM: 0772a2bd8cd4c7aaeb2576ddfaf6b03be722593b
 
-COCOAPODS: 1.15.2
+COCOAPODS: 1.16.2

--- a/packages/reown_walletkit/example/lib/dependencies/i_walletkit_service.dart
+++ b/packages/reown_walletkit/example/lib/dependencies/i_walletkit_service.dart
@@ -1,15 +1,12 @@
+import 'package:flutter/foundation.dart';
 import 'package:get_it/get_it.dart';
 import 'package:reown_walletkit/reown_walletkit.dart';
-
-// class UpdateEvent extends EventArgs {
-//   final bool loading;
-
-//   UpdateEvent({required this.loading});
-// }
+import 'package:reown_walletkit_wallet/models/chain_metadata.dart';
 
 abstract class IWalletKitService extends Disposable {
   Future<void> create();
   Future<void> init();
 
+  abstract final ValueNotifier<ChainMetadata?> currentSelectedChain;
   ReownWalletKit get walletKit;
 }

--- a/packages/reown_walletkit/example/lib/dependencies/walletkit_service.dart
+++ b/packages/reown_walletkit/example/lib/dependencies/walletkit_service.dart
@@ -12,6 +12,7 @@ import 'package:reown_walletkit_wallet/dependencies/i_walletkit_service.dart';
 import 'package:reown_walletkit_wallet/dependencies/key_service/chain_key.dart';
 import 'package:reown_walletkit_wallet/dependencies/key_service/i_key_service.dart';
 import 'package:reown_walletkit_wallet/models/chain_data.dart';
+import 'package:reown_walletkit_wallet/models/chain_metadata.dart';
 import 'package:reown_walletkit_wallet/utils/dart_defines.dart';
 import 'package:reown_walletkit_wallet/utils/eth_utils.dart';
 import 'package:reown_walletkit_wallet/utils/methods_utils.dart';
@@ -46,6 +47,13 @@ class WalletKitService extends IWalletKitService {
       linkMode: linkModeEnabled,
     );
   }
+
+  @override
+  final ValueNotifier<ChainMetadata?> currentSelectedChain = ValueNotifier(
+    ChainsDataList.eip155Chains.firstWhere(
+      (e) => e.chainId == 'eip155:1',
+    ),
+  );
 
   @override
   Future<void> create() async {


### PR DESCRIPTION
# Description

Added `wallet_addEthereumChain` capability on WalletKit sample Wallet.

## How Has This Been Tested?

#### What do you see in this demo video:

1. First you can see WalletKit sample Wallet only supports Ethereum mainnet at the beginning
2. Then Connection is triggered on Sushiswap side
3. WalletKit Wallet only approves `eip155:1` since is the only one that supports
4. Moonbeam is then selected on Sushiswap triggering a `wallet_switchEthereumChain`
5. WalletKit Wallet fails at `wallet_switchEthereumChain` since Moonbeam is not supported/added so `wallet_addEthereumChain` is silently triggered on Moonbeam upon receiving the error.
6. WalletKit Wallet now shows the `wallet_addEthereumChain` approval modal and upon approval it switches to it and adds this blockchain the the list of supported blockchains 
7. You can see now Sushiswap is set on Moonbeam and ready to be used


#### Core logic on point 6 happens during `Future<void> addChain(String topic, dynamic parameters)` handler:

1. `wallet_addEthereumChain` request is intercepted
2. parameters are parsed
3. `_walletKit.registerEventEmitter()` and `_walletKit.registerRequestHandler()` are called by registering a new `EVMService` for the new chain
    So basically this constructor is getting called for the new chain:
    
```dart
EVMService({required this.chainSupported}) {
  ethClient = Web3Client(chainSupported.rpc.first, http.Client());

  for (final event in EventsConstants.allEvents) {
    _walletKit.registerEventEmitter(
      chainId: chainSupported.chainId,
      event: event,
    );
  }

  for (var handler in methodRequestHandlers.entries) {
    _walletKit.registerRequestHandler(
      chainId: chainSupported.chainId,
      method: handler.key,
      handler: handler.value,
    );
  }
  for (var handler in sessionRequestHandlers.entries) {
    _walletKit.registerRequestHandler(
      chainId: chainSupported.chainId,
      method: handler.key,
      handler: handler.value,
    );
  }

  _walletKit.onSessionRequest.subscribe(_onSessionRequest);
}
```
  
4. `_walletKit.registerAccount()` is getting called
5. `_walletKit.updateSession()` is getting called
6. `chainChanged` event is emitted by switching to the new chain with `currentSelectedChain`


https://github.com/user-attachments/assets/b7628cd3-e699-47f4-bccc-b20fb04f9581

## Due Dilligence

* [ ] Breaking change
* [ ] Requires a documentation update