### PR TITLE
Implementation of solana_signAndSendTransaction

### DIFF
--- a/packages/reown_appkit/example/base/lib/pages/connect_page.dart
+++ b/packages/reown_appkit/example/base/lib/pages/connect_page.dart
@@ -63,13 +63,17 @@ class ConnectPageState extends State<ConnectPage> {
   }
 
   Future<void> _refreshData() async {
-    await widget.appKitModal.reconnectRelay();
-    await widget.appKitModal.loadAccountData();
-    final topic = widget.appKitModal.session!.topic ?? '';
-    if (topic.isNotEmpty) {
-      await widget.appKitModal.appKit!.ping(topic: topic);
+    try {
+      await widget.appKitModal.reconnectRelay();
+      await widget.appKitModal.loadAccountData();
+      final topic = widget.appKitModal.session!.topic ?? '';
+      if (topic.isNotEmpty) {
+        await widget.appKitModal.appKit!.ping(topic: topic);
+      }
+      setState(() {});
+    } catch (e) {
+      debugPrint(e.toString());
     }
-    setState(() {});
   }
 
   @override
@@ -78,7 +82,7 @@ class ConnectPageState extends State<ConnectPage> {
     final isDarkMode =
         ReownAppKitModalTheme.maybeOf(context)?.isDarkMode ?? false;
     return RefreshIndicator(
-      onRefresh: () => _refreshData(),
+      onRefresh: _refreshData,
       child: Stack(
         children: [
           Center(

--- a/packages/reown_appkit/example/base/lib/utils/crypto/helpers.dart
+++ b/packages/reown_appkit/example/base/lib/utils/crypto/helpers.dart
@@ -113,12 +113,12 @@ Future<SessionRequestParams?> getParams(
       );
     case 'solana_signTransaction':
     case 'solana_signAndSendTransaction':
-      final transactionV0 = await _contructSolanaTX(address, chainData);
+      final transactionV0_2 = await _contructSolanaTX_2(address, chainData);
 
       const config = solana.TransactionSerializableConfig(
         verifySignatures: false,
       );
-      final bytes = transactionV0.serialize(config).asUint8List();
+      final bytes = transactionV0_2.serialize(config).asUint8List();
       final encodedV0Trx = base64.encode(bytes);
 
       return SessionRequestParams(
@@ -127,7 +127,7 @@ Future<SessionRequestParams?> getParams(
           'transaction': encodedV0Trx,
           'pubkey': address,
           'feePayer': address,
-          ...transactionV0.message.toJson(),
+          ...transactionV0_2.message.toJson(),
         },
       );
     case 'solana_signAllTransactions':
@@ -233,8 +233,8 @@ Future<solana.Transaction> _contructSolanaTX_2(
   final blockhash = await connection.getLatestBlockhash();
 
   // Define transfer amount in lamports (1 SOL = 1,000,000,000 lamports)
-  // Amount to send in lamports (0.001 SOL)
-  final lamports = BigInt.from(1000000);
+  // Amount to send in lamports (0.01 SOL)
+  final lamports = BigInt.from(10000000);
 
   // Create the transfer instruction
   final transferInstruction = programs.SystemProgram.transfer(

--- a/packages/reown_walletkit/example/lib/main.dart
+++ b/packages/reown_walletkit/example/lib/main.dart
@@ -141,8 +141,12 @@ class _MyHomePageState extends State<MyHomePage> {
     // Support Solana Chains
     // Change SolanaService to SolanaService2 to switch between `solana` package and `solana_web3` package
     for (final chainData in ChainsDataList.solanaChains) {
-      GetIt.I.registerSingleton<SolanaService>(
-        SolanaService(chainSupported: chainData),
+      GetIt.I.registerSingletonAsync<SolanaService>(
+        () async {
+          final service = SolanaService(chainSupported: chainData);
+          await service.init();
+          return service;
+        },
         instanceName: chainData.chainId,
       );
     }


### PR DESCRIPTION
# Description

Implementation example of `solana_signAndSendTransaction` method using [solana package](https://pub.dev/packages/solana) for Dart.

Resolves https://github.com/reown-com/reown_flutter/issues/119

## How Has This Been Tested?

Sent a transaction over testnet https://solscan.io/tx/5uhSsAXCqQocS4sr6jqUXdxJcm5NVV6XFM8Qasm5ZrJPRt1BA3r6FmUeK3AhNiJqqhPijB3c8Hz3CKoeoBPAa7F8?cluster=testnet

## Due Dilligence

* [ ] Breaking change
* [ ] Requires a documentation update