### PR TITLE
Extend instance init to allow core and chain abstraction params for b…

### DIFF
--- a/packages/reown_appkit/lib/base/appkit_base_impl.dart
+++ b/packages/reown_appkit/lib/base/appkit_base_impl.dart
@@ -43,26 +43,11 @@ class ReownAppKit implements IReownAppKit {
     return client;
   }
 
-  ///---------- GENERIC ----------///
-
-  @override
-  final String protocol = 'wc';
-
-  @override
-  final int version = 2;
-
-  @override
-  final IReownCore core;
-
-  @override
-  final PairingMetadata metadata;
-
-  ///
-  ReownAppKit({
-    required this.core,
-    required this.metadata,
+  static ReownSign createReOwnSignInstance({
+    required IReownCore core,
+    required PairingMetadata metadata,
   }) {
-    reOwnSign = ReownSign(
+    return ReownSign(
       core: core,
       metadata: metadata,
       proposals: GenericStore(
@@ -114,6 +99,29 @@ class ReownAppKit implements IReownAppKit {
         },
       ),
     );
+  }
+
+  ///---------- GENERIC ----------///
+
+  @override
+  final String protocol = 'wc';
+
+  @override
+  final int version = 2;
+
+  @override
+  final IReownCore core;
+
+  @override
+  final PairingMetadata metadata;
+
+  ///
+  ReownAppKit(
+      {required this.core,
+      required this.metadata,
+      ReownSign? overrideReOwnSign}) {
+    reOwnSign = overrideReOwnSign ??
+        createReOwnSignInstance(core: core, metadata: metadata);
   }
 
   @override

--- a/packages/reown_walletkit/lib/walletkit_impl.dart
+++ b/packages/reown_walletkit/lib/walletkit_impl.dart
@@ -37,25 +37,11 @@ class ReownWalletKit with WidgetsBindingObserver implements IReownWalletKit {
     return walletKit;
   }
 
-  ///---------- GENERIC ----------///
-
-  @override
-  final String protocol = 'wc';
-
-  @override
-  final int version = 2;
-
-  @override
-  final IReownCore core;
-
-  @override
-  final PairingMetadata metadata;
-
-  ReownWalletKit({
-    required this.core,
-    required this.metadata,
+  static ReownSign createReOwnSignInstance({
+    required IReownCore core,
+    required PairingMetadata metadata,
   }) {
-    reOwnSign = ReownSign(
+    return ReownSign(
       core: core,
       metadata: metadata,
       proposals: GenericStore(
@@ -107,8 +93,13 @@ class ReownWalletKit with WidgetsBindingObserver implements IReownWalletKit {
         },
       ),
     );
+  }
 
-    chainAbstraction = ChainAbstraction(
+  static ChainAbstraction createChainAbstraction({
+    required IReownCore core,
+    required PairingMetadata metadata,
+  }) {
+    return ChainAbstraction(
       core: core,
       pulseMetadata: PulseMetadataCompat(
         url: metadata.url,
@@ -116,6 +107,31 @@ class ReownWalletKit with WidgetsBindingObserver implements IReownWalletKit {
         sdkPlatform: ReownCoreUtils.getId(),
       ),
     );
+  }
+
+  ///---------- GENERIC ----------///
+
+  @override
+  final String protocol = 'wc';
+
+  @override
+  final int version = 2;
+
+  @override
+  final IReownCore core;
+
+  @override
+  final PairingMetadata metadata;
+
+  ReownWalletKit(
+      {required this.core,
+      required this.metadata,
+      ReownSign? overrideReOwnSign,
+      ChainAbstraction? overrideChainAbstraction}) {
+    reOwnSign = overrideReOwnSign ??
+        createReOwnSignInstance(core: core, metadata: metadata);
+    chainAbstraction = overrideChainAbstraction ??
+        createChainAbstraction(core: core, metadata: metadata);
   }
 
   @override


### PR DESCRIPTION
…oth wallet and app kit usage

# Description

There are some projects using both WalletKit and AppKit but the current implementation of constructor just allow to use only one of that kit.
So now i extend it to support optional params, static method to create required instance, then we are able to init both WalletKit and AppKit to use in single project.