### PR TITLE
Only validate namespace methods if registerRequestHandler is used.

### DIFF
--- a/packages/reown_appkit/example/base/lib/pages/connect_page.dart
+++ b/packages/reown_appkit/example/base/lib/pages/connect_page.dart
@@ -235,6 +235,31 @@ class __RequestButtonsState extends State<_RequestButtons> {
       chainId,
     );
     final implemented = getChainMethods(namespace);
+    if ((approvedMethods ?? []).isEmpty) {
+      // if no methods where registered by the wallet...
+      return Container(
+        height: 40.0,
+        width: double.infinity,
+        margin: const EdgeInsets.symmetric(vertical: StyleConstants.linear8),
+        child: ElevatedButton(
+          onPressed: () async {
+            final params = await getParams(
+              'personal_sign',
+              address,
+              chainInfo!,
+            );
+            widget.appKitModal.launchConnectedWallet();
+            final future = widget.appKitModal.request(
+              topic: topic,
+              chainId: chainId,
+              request: params!,
+            );
+            MethodDialog.show(context, 'personal_sign', future);
+          },
+          child: Text('personal_sign'),
+        ),
+      );
+    }
     return Column(
       children: (approvedMethods ?? []).map((method) {
         final enabled = implemented.contains(method);

--- a/packages/reown_appkit/pubspec.yaml
+++ b/packages/reown_appkit/pubspec.yaml
@@ -29,12 +29,12 @@ dependencies:
   pinenacl: ^0.6.0
   plugin_platform_interface: ^2.1.8
   qr_flutter_wc: ^0.0.3
-  reown_core: ^1.1.4+1
-  # reown_core:
-  #   path: ../reown_core/
-  reown_sign: ^1.1.4+1
-  # reown_sign:
-  #   path: ../reown_sign/
+  # reown_core: ^1.1.4+1
+  reown_core:
+    path: ../reown_core/
+  # reown_sign: ^1.1.4+1
+  reown_sign:
+    path: ../reown_sign/
   shimmer: ^3.0.0
   synchronized: ^3.3.0+3
   web_socket_channel: ^3.0.1

--- a/packages/reown_sign/lib/sign_engine.dart
+++ b/packages/reown_sign/lib/sign_engine.dart
@@ -1068,7 +1068,7 @@ class ReownSign implements IReownSign {
 
       // If there are accounts and event emitters, then handle the Namespace generate automatically
       Map<String, Namespace>? namespaces;
-      if (_accounts.isNotEmpty || _eventEmitters.isNotEmpty) {
+      if (_accounts.isNotEmpty) {
         namespaces = NamespaceUtils.constructNamespaces(
           availableAccounts: _accounts,
           availableMethods: _methodHandlers.keys.toSet(),

--- a/packages/reown_sign/lib/utils/sign_api_validator_utils.dart
+++ b/packages/reown_sign/lib/utils/sign_api_validator_utils.dart
@@ -159,6 +159,10 @@ class SignApiValidatorUtils {
       chainId: chainId,
     );
 
+    // if methods is empty it means no request handlers were registered by the wallet usin `registerRequestHandler`
+    // so by returnig `true` here we make sure the request is still sent through onSessionRequest event
+    if (methods.isEmpty) return true;
+
     if (!methods.contains(method)) {
       throw Errors.getSdkError(
         Errors.UNSUPPORTED_METHODS,

--- a/packages/reown_sign/pubspec.yaml
+++ b/packages/reown_sign/pubspec.yaml
@@ -15,9 +15,9 @@ dependencies:
   freezed_annotation: ^2.4.4
   http: ^1.2.2
   pointycastle: ^3.9.1
-  reown_core: ^1.1.4+1
-  # reown_core:
-  #   path: ../reown_core/
+  # reown_core: ^1.1.4+1
+  reown_core:
+    path: ../reown_core/
   web3dart: ^2.7.3
 
 dev_dependencies:

--- a/packages/reown_walletkit/example/ios/Runner.xcodeproj/project.pbxproj
+++ b/packages/reown_walletkit/example/ios/Runner.xcodeproj/project.pbxproj
@@ -10,11 +10,11 @@
 		091D8F542C4A7A5000904D6C /* Info-internal.plist in Resources */ = {isa = PBXBuildFile; fileRef = 091D8F532C4A7A5000904D6C /* Info-internal.plist */; };
 		1498D2341E8E89220040F4C2 /* GeneratedPluginRegistrant.m in Sources */ = {isa = PBXBuildFile; fileRef = 1498D2331E8E89220040F4C2 /* GeneratedPluginRegistrant.m */; };
 		3B3967161E833CAA004F5970 /* AppFrameworkInfo.plist in Resources */ = {isa = PBXBuildFile; fileRef = 3B3967151E833CAA004F5970 /* AppFrameworkInfo.plist */; };
-		3E38B91FF4818DE4AB4C48A0 /* Pods_Runner.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 1F1CCFDCA1C36E9E97E29222 /* Pods_Runner.framework */; };
 		74858FAF1ED2DC5600515810 /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 74858FAE1ED2DC5600515810 /* AppDelegate.swift */; };
 		97C146FC1CF9000F007C117D /* Main.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 97C146FA1CF9000F007C117D /* Main.storyboard */; };
 		97C146FE1CF9000F007C117D /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 97C146FD1CF9000F007C117D /* Assets.xcassets */; };
 		97C147011CF9000F007C117D /* LaunchScreen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 97C146FF1CF9000F007C117D /* LaunchScreen.storyboard */; };
+		D8942920EE3AD01D3FDA8D18 /* Pods_Runner.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 73D263A3900B32FA8E839CF9 /* Pods_Runner.framework */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXCopyFilesBuildPhase section */
@@ -35,14 +35,15 @@
 		0978D7E02C6B682E00E3593C /* Runner.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; path = Runner.entitlements; sourceTree = "<group>"; };
 		1498D2321E8E86230040F4C2 /* GeneratedPluginRegistrant.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = GeneratedPluginRegistrant.h; sourceTree = "<group>"; };
 		1498D2331E8E89220040F4C2 /* GeneratedPluginRegistrant.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = GeneratedPluginRegistrant.m; sourceTree = "<group>"; };
-		1F1CCFDCA1C36E9E97E29222 /* Pods_Runner.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_Runner.framework; sourceTree = BUILT_PRODUCTS_DIR; };
-		29B987B381EAF363021861B4 /* Pods-Runner.profile-internal.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Runner.profile-internal.xcconfig"; path = "Target Support Files/Pods-Runner/Pods-Runner.profile-internal.xcconfig"; sourceTree = "<group>"; };
+		382B55652D6A253DDA83C9A7 /* Pods-Runner.release-production.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Runner.release-production.xcconfig"; path = "Target Support Files/Pods-Runner/Pods-Runner.release-production.xcconfig"; sourceTree = "<group>"; };
 		3B3967151E833CAA004F5970 /* AppFrameworkInfo.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; name = AppFrameworkInfo.plist; path = Flutter/AppFrameworkInfo.plist; sourceTree = "<group>"; };
-		427578C2828A12AFA007D8A8 /* Pods-Runner.debug-production.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Runner.debug-production.xcconfig"; path = "Target Support Files/Pods-Runner/Pods-Runner.debug-production.xcconfig"; sourceTree = "<group>"; };
-		49F983EAD972668E8A6F3290 /* Pods-Runner.release-production.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Runner.release-production.xcconfig"; path = "Target Support Files/Pods-Runner/Pods-Runner.release-production.xcconfig"; sourceTree = "<group>"; };
+		445D99D2E0271B12516011E2 /* Pods-Runner.debug-production.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Runner.debug-production.xcconfig"; path = "Target Support Files/Pods-Runner/Pods-Runner.debug-production.xcconfig"; sourceTree = "<group>"; };
+		73D263A3900B32FA8E839CF9 /* Pods_Runner.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_Runner.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		74858FAD1ED2DC5600515810 /* Runner-Bridging-Header.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "Runner-Bridging-Header.h"; sourceTree = "<group>"; };
 		74858FAE1ED2DC5600515810 /* AppDelegate.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
 		7AFA3C8E1D35360C0083082E /* Release.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; name = Release.xcconfig; path = Flutter/Release.xcconfig; sourceTree = "<group>"; };
+		813A13335FC3BC9B90578A20 /* Pods-Runner.debug-internal.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Runner.debug-internal.xcconfig"; path = "Target Support Files/Pods-Runner/Pods-Runner.debug-internal.xcconfig"; sourceTree = "<group>"; };
+		8CBCEE4877BD5D0B8B2ED928 /* Pods-Runner.profile-production.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Runner.profile-production.xcconfig"; path = "Target Support Files/Pods-Runner/Pods-Runner.profile-production.xcconfig"; sourceTree = "<group>"; };
 		9740EEB21CF90195004384FC /* Debug.xcconfig */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xcconfig; name = Debug.xcconfig; path = Flutter/Debug.xcconfig; sourceTree = "<group>"; };
 		9740EEB31CF90195004384FC /* Generated.xcconfig */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xcconfig; name = Generated.xcconfig; path = Flutter/Generated.xcconfig; sourceTree = "<group>"; };
 		97C146EE1CF9000F007C117D /* Runner.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = Runner.app; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -50,9 +51,8 @@
 		97C146FD1CF9000F007C117D /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
 		97C147001CF9000F007C117D /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; name = Base; path = Base.lproj/LaunchScreen.storyboard; sourceTree = "<group>"; };
 		97C147021CF9000F007C117D /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
-		AACC713EACE1591F9CE8CE32 /* Pods-Runner.debug-internal.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Runner.debug-internal.xcconfig"; path = "Target Support Files/Pods-Runner/Pods-Runner.debug-internal.xcconfig"; sourceTree = "<group>"; };
-		CC4F506B00EA0EAC764E3390 /* Pods-Runner.release-internal.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Runner.release-internal.xcconfig"; path = "Target Support Files/Pods-Runner/Pods-Runner.release-internal.xcconfig"; sourceTree = "<group>"; };
-		FA0C26BB5626867D3B71D82D /* Pods-Runner.profile-production.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Runner.profile-production.xcconfig"; path = "Target Support Files/Pods-Runner/Pods-Runner.profile-production.xcconfig"; sourceTree = "<group>"; };
+		CFB7A41B37E739BCB54C28D4 /* Pods-Runner.profile-internal.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Runner.profile-internal.xcconfig"; path = "Target Support Files/Pods-Runner/Pods-Runner.profile-internal.xcconfig"; sourceTree = "<group>"; };
+		EB3EB32AB9B95E04AACC00F8 /* Pods-Runner.release-internal.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Runner.release-internal.xcconfig"; path = "Target Support Files/Pods-Runner/Pods-Runner.release-internal.xcconfig"; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -60,7 +60,7 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				3E38B91FF4818DE4AB4C48A0 /* Pods_Runner.framework in Frameworks */,
+				D8942920EE3AD01D3FDA8D18 /* Pods_Runner.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -85,7 +85,7 @@
 				97C146F01CF9000F007C117D /* Runner */,
 				97C146EF1CF9000F007C117D /* Products */,
 				C4281BF2C021B5570082F0DC /* Pods */,
-				B38F3A7C69BF001DC12E417D /* Frameworks */,
+				C8007456A2775F2C4228D5CB /* Frameworks */,
 			);
 			sourceTree = "<group>";
 		};
@@ -114,25 +114,25 @@
 			path = Runner;
 			sourceTree = "<group>";
 		};
-		B38F3A7C69BF001DC12E417D /* Frameworks */ = {
-			isa = PBXGroup;
-			children = (
-				1F1CCFDCA1C36E9E97E29222 /* Pods_Runner.framework */,
-			);
-			name = Frameworks;
-			sourceTree = "<group>";
-		};
 		C4281BF2C021B5570082F0DC /* Pods */ = {
 			isa = PBXGroup;
 			children = (
-				427578C2828A12AFA007D8A8 /* Pods-Runner.debug-production.xcconfig */,
-				AACC713EACE1591F9CE8CE32 /* Pods-Runner.debug-internal.xcconfig */,
-				49F983EAD972668E8A6F3290 /* Pods-Runner.release-production.xcconfig */,
-				CC4F506B00EA0EAC764E3390 /* Pods-Runner.release-internal.xcconfig */,
-				FA0C26BB5626867D3B71D82D /* Pods-Runner.profile-production.xcconfig */,
-				29B987B381EAF363021861B4 /* Pods-Runner.profile-internal.xcconfig */,
+				445D99D2E0271B12516011E2 /* Pods-Runner.debug-production.xcconfig */,
+				813A13335FC3BC9B90578A20 /* Pods-Runner.debug-internal.xcconfig */,
+				382B55652D6A253DDA83C9A7 /* Pods-Runner.release-production.xcconfig */,
+				EB3EB32AB9B95E04AACC00F8 /* Pods-Runner.release-internal.xcconfig */,
+				8CBCEE4877BD5D0B8B2ED928 /* Pods-Runner.profile-production.xcconfig */,
+				CFB7A41B37E739BCB54C28D4 /* Pods-Runner.profile-internal.xcconfig */,
 			);
 			path = Pods;
+			sourceTree = "<group>";
+		};
+		C8007456A2775F2C4228D5CB /* Frameworks */ = {
+			isa = PBXGroup;
+			children = (
+				73D263A3900B32FA8E839CF9 /* Pods_Runner.framework */,
+			);
+			name = Frameworks;
 			sourceTree = "<group>";
 		};
 /* End PBXGroup section */
@@ -142,14 +142,14 @@
 			isa = PBXNativeTarget;
 			buildConfigurationList = 97C147051CF9000F007C117D /* Build configuration list for PBXNativeTarget "Runner" */;
 			buildPhases = (
-				E1198364695B28F5AF308223 /* [CP] Check Pods Manifest.lock */,
+				ECBDE70FEE678683AC3FB875 /* [CP] Check Pods Manifest.lock */,
 				9740EEB61CF901F6004384FC /* Run Script */,
 				97C146EA1CF9000F007C117D /* Sources */,
 				97C146EB1CF9000F007C117D /* Frameworks */,
 				97C146EC1CF9000F007C117D /* Resources */,
 				9705A1C41CF9048500538489 /* Embed Frameworks */,
 				3B06AD1E1E4923F5004D2608 /* Thin Binary */,
-				2198D9FA46A38BD0B36903BC /* [CP] Embed Pods Frameworks */,
+				347869E4CFE6EB7C192FA455 /* [CP] Embed Pods Frameworks */,
 			);
 			buildRules = (
 			);
@@ -209,7 +209,7 @@
 /* End PBXResourcesBuildPhase section */
 
 /* Begin PBXShellScriptBuildPhase section */
-		2198D9FA46A38BD0B36903BC /* [CP] Embed Pods Frameworks */ = {
+		347869E4CFE6EB7C192FA455 /* [CP] Embed Pods Frameworks */ = {
 			isa = PBXShellScriptBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
@@ -257,7 +257,7 @@
 			shellPath = /bin/sh;
 			shellScript = "/bin/sh \"$FLUTTER_ROOT/packages/flutter_tools/bin/xcode_backend.sh\" build";
 		};
-		E1198364695B28F5AF308223 /* [CP] Check Pods Manifest.lock */ = {
+		ECBDE70FEE678683AC3FB875 /* [CP] Check Pods Manifest.lock */ = {
 			isa = PBXShellScriptBuildPhase;
 			buildActionMask = 2147483647;
 			files = (

--- a/packages/reown_walletkit/example/lib/dependencies/chain_services/evm_service.dart
+++ b/packages/reown_walletkit/example/lib/dependencies/chain_services/evm_service.dart
@@ -57,16 +57,13 @@ class EVMService {
   final ChainMetadata chainSupported;
   late final Web3Client ethClient;
 
-  Map<String, dynamic Function(String, dynamic)> get sessionRequestHandlers => {
+  Map<String, dynamic Function(String, dynamic)> get methodRequestHandlers => {
         SupportedEVMMethods.ethSign.name: ethSignHandler,
         SupportedEVMMethods.ethSignTransaction.name: ethSignTransactionHandler,
         SupportedEVMMethods.ethSignTypedData.name: ethSignTypedDataHandler,
         SupportedEVMMethods.ethSignTypedDataV4.name: ethSignTypedDataV4Handler,
         SupportedEVMMethods.switchChain.name: switchChainHandler,
         SupportedEVMMethods.addChain.name: addChainHandler,
-      };
-
-  Map<String, dynamic Function(String, dynamic)> get methodRequestHandlers => {
         SupportedEVMMethods.personalSign.name: personalSignHandler,
         SupportedEVMMethods.ethSendTransaction.name: ethSendTransactionHandler,
       };
@@ -81,20 +78,13 @@ class EVMService {
       );
     }
 
-    for (var handler in methodRequestHandlers.entries) {
-      _walletKit.registerRequestHandler(
-        chainId: chainSupported.chainId,
-        method: handler.key,
-        handler: handler.value,
-      );
-    }
-    for (var handler in sessionRequestHandlers.entries) {
-      _walletKit.registerRequestHandler(
-        chainId: chainSupported.chainId,
-        method: handler.key,
-        handler: handler.value,
-      );
-    }
+    // for (var handler in methodRequestHandlers.entries) {
+    //   _walletKit.registerRequestHandler(
+    //     chainId: chainSupported.chainId,
+    //     method: handler.key,
+    //     handler: handler.value,
+    //   );
+    // }
 
     _walletKit.onSessionRequest.subscribe(_onSessionRequest);
   }
@@ -959,11 +949,24 @@ class EVMService {
   }
 
   void _onSessionRequest(SessionRequestEvent? args) async {
-    if (args != null && args.chainId == chainSupported.chainId) {
-      debugPrint('[SampleWallet] _onSessionRequest ${args.toString()}');
-      final handler = sessionRequestHandlers[args.method];
+    if (args == null) return;
+
+    debugPrint('[SampleWallet] _onSessionRequest ${args.toString()}');
+    if (args.chainId == chainSupported.chainId) {
+      final handler = methodRequestHandlers[args.method];
       if (handler != null) {
         await handler(args.topic, args.params);
+      } else {
+        final error = Errors.getSdkError(Errors.UNSUPPORTED_METHODS);
+        final response = JsonRpcResponse(
+          id: args.id,
+          jsonrpc: '2.0',
+          error: JsonRpcError(
+            code: error.code,
+            message: error.message,
+          ),
+        );
+        _handleResponseForTopic(args.topic, response);
       }
     }
   }

--- a/packages/reown_walletkit/example/lib/dependencies/walletkit_service.dart
+++ b/packages/reown_walletkit/example/lib/dependencies/walletkit_service.dart
@@ -226,7 +226,7 @@ class WalletKitService extends IWalletKitService {
           _walletKit!.approveSession(
             id: args.id,
             namespaces: NamespaceUtils.regenerateNamespacesWithChains(
-              args.params.generatedNamespaces!,
+              args.params.generatedNamespaces ?? {},
             ),
             sessionProperties: args.params.sessionProperties,
           );

--- a/packages/reown_walletkit/example/lib/utils/namespace_model_builder.dart
+++ b/packages/reown_walletkit/example/lib/utils/namespace_model_builder.dart
@@ -22,18 +22,16 @@ class ConnectionWidgetBuilder {
       );
       models.add(
         WCConnectionModel(
+          title: StringConstants.events,
+          elements: namespaces.events,
+        ),
+      );
+      models.add(
+        WCConnectionModel(
           title: StringConstants.methods,
           elements: namespaces.methods,
         ),
       );
-      if (namespaces.events.isNotEmpty) {
-        models.add(
-          WCConnectionModel(
-            title: StringConstants.events,
-            elements: namespaces.events,
-          ),
-        );
-      }
 
       views.add(
         WCConnectionWidget(
@@ -64,19 +62,16 @@ class ConnectionWidgetBuilder {
       );
       models.add(
         WCConnectionModel(
+          title: StringConstants.events,
+          elements: ns.events,
+        ),
+      );
+      models.add(
+        WCConnectionModel(
           title: StringConstants.methods,
           elements: ns.methods,
         ),
       );
-
-      if (ns.events.isNotEmpty) {
-        models.add(
-          WCConnectionModel(
-            title: StringConstants.events,
-            elements: ns.events,
-          ),
-        );
-      }
 
       views.add(
         WCConnectionWidget(

--- a/packages/reown_walletkit/example/lib/widgets/wc_connection_request/wc_connection_request_widget.dart
+++ b/packages/reown_walletkit/example/lib/widgets/wc_connection_request/wc_connection_request_widget.dart
@@ -95,7 +95,7 @@ class WCConnectionRequestWidget extends StatelessWidget {
     // Create the connection models using the required and optional namespaces provided by the proposal data
     // The key is the title and the list of values is the data
     final views = ConnectionWidgetBuilder.buildFromRequiredNamespaces(
-      proposalData!.generatedNamespaces!,
+      proposalData!.generatedNamespaces ?? {},
     );
 
     return Column(

--- a/packages/reown_walletkit/pubspec.yaml
+++ b/packages/reown_walletkit/pubspec.yaml
@@ -12,15 +12,15 @@ dependencies:
   event: ^3.1.0
   flutter:
     sdk: flutter
-  reown_core: ^1.1.4+1
-  # reown_core:
-  #   path: ../reown_core/
-  reown_sign: ^1.1.4+1
-  # reown_sign:
-  #   path: ../reown_sign/
-  reown_yttrium: ^0.0.1
-  # reown_yttrium:
-  #    path: ../reown_yttrium/
+  # reown_core: ^1.1.4+1
+  reown_core:
+    path: ../reown_core/
+  # reown_sign: ^1.1.4+1
+  reown_sign:
+    path: ../reown_sign/
+  # reown_yttrium: ^0.0.1
+  reown_yttrium:
+     path: ../reown_yttrium/
 
 
 dev_dependencies:
@@ -34,9 +34,9 @@ dev_dependencies:
   logger: ^2.5.0
   mockito: ^5.4.4
   package_info_plus: ^8.1.2
-  reown_appkit: ^1.4.2
-  # reown_appkit:
-  #   path: ../reown_appkit/
+  # reown_appkit: ^1.4.2
+  reown_appkit:
+    path: ../reown_appkit/
 
 platforms:
   android:


### PR DESCRIPTION
# Description

There was an issue where if the wallet was not using registerRequestHandlers to handle session request then onSessionRequest subscription was not getting called.

Only validate namespace methods if registerRequestHandler is used.

Resolves https://github.com/reown-com/reown_flutter/issues/136

## How Has This Been Tested?

- Integration tests
- Manual tests

## Due Dilligence

* [ ] Breaking change
* [ ] Requires a documentation update