### PR TITLE
migrated to webthree

### DIFF
--- a/packages/reown_sign/lib/reown_sign.dart
+++ b/packages/reown_sign/lib/reown_sign.dart
@@ -25,6 +25,6 @@ export 'sign_client.dart';
 export 'i_sign_engine.dart';
 export 'sign_engine.dart';
 
-export 'package:web3dart/web3dart.dart';
-export 'package:web3dart/crypto.dart' hide bytesToHex;
-export 'package:web3dart/json_rpc.dart';
+export 'package:webthree/webthree.dart';
+export 'package:webthree/crypto.dart' hide bytesToHex;
+export 'package:webthree/json_rpc.dart';

--- a/packages/reown_sign/lib/utils/address_utils.dart
+++ b/packages/reown_sign/lib/utils/address_utils.dart
@@ -1,4 +1,4 @@
-// import 'package:web3dart/web3dart.dart';
+// import 'package:webthree/webthree.dart';
 
 class AddressUtils {
   static String getDidAddress(String iss) {

--- a/packages/reown_sign/lib/utils/auth_signature.dart
+++ b/packages/reown_sign/lib/utils/auth_signature.dart
@@ -12,7 +12,7 @@ import 'package:reown_sign/models/basic_models.dart';
 import 'package:reown_sign/utils/address_utils.dart';
 import 'package:reown_sign/utils/constants.dart';
 import 'package:reown_sign/utils/recaps_utils.dart';
-import 'package:web3dart/crypto.dart' as crypto;
+import 'package:webthree/crypto.dart' as crypto;
 
 class AuthSignature {
   static final KeccakDigest keccakDigest = KeccakDigest(256);

--- a/packages/reown_sign/lib/utils/extensions.dart
+++ b/packages/reown_sign/lib/utils/extensions.dart
@@ -1,8 +1,8 @@
 import 'dart:typed_data';
 
 import 'package:convert/convert.dart';
-import 'package:web3dart/crypto.dart' as crypto;
-import 'package:web3dart/web3dart.dart';
+import 'package:webthree/crypto.dart' as crypto;
+import 'package:webthree/webthree.dart';
 
 import 'package:reown_core/reown_core.dart';
 import 'package:reown_sign/models/basic_models.dart';

--- a/packages/reown_sign/pubspec.yaml
+++ b/packages/reown_sign/pubspec.yaml
@@ -18,7 +18,7 @@ dependencies:
   reown_core: ^1.1.4+1
   # reown_core:
   #   path: ../reown_core/
-  web3dart: ^2.7.3
+  webthree: ^2.7.5
 
 dev_dependencies:
   build_runner: ^2.4.13


### PR DESCRIPTION
# Description

[WebThree](https://github.com/devopsdao/webthree) - a web3 library for dart that allows you to interact with a local or remote ethereum node using HTTP or WebSocket. Suports custom credentials providers like WalletConnect and Metamask.

Fork of original [web3dart](https://github.com/simolus3/web3dart) 2.3.5 by simolus3, incorporating all changes from other forks.

Well maintained by Dodao and Archethic contributors

Resolves # (issue)

## How Has This Been Tested?

test of develop branch before migration:
01:55 +72 -38: Some tests failed.

test of develop branch after migration:
01:55 +72 -38: Some tests failed.

same test results.
