### PR TITLE
feat(cicd): implement automated Flutter package publishing workflow

### DIFF
--- a/.github/scripts/wait_for_package.sh
+++ b/.github/scripts/wait_for_package.sh
@@ -1,0 +1,40 @@
+#!/bin/bash
+# .github/scripts/wait_for_package.sh
+
+# Script to wait for a package version to be available on pub.dev
+# Arguments:
+#   $1: Package name (e.g., reown_core)
+#   $2: Package version (e.g., 1.0.0)
+
+set -e # Exit immediately if a command exits with a non-zero status.
+
+PACKAGE_NAME=$1
+PACKAGE_VERSION=$2
+MAX_ATTEMPTS=${3:-30} # Maximum number of attempts (default 30, approx 5 minutes if sleep is 10s)
+SLEEP_DURATION=${4:-10} # Sleep duration in seconds between attempts (default 10s)
+
+if [ -z "$PACKAGE_NAME" ] || [ -z "$PACKAGE_VERSION" ]; then
+  echo "Usage: $0 <package_name> <package_version> [max_attempts] [sleep_duration]"
+  exit 1
+fi
+
+echo "Waiting for package '$PACKAGE_NAME' version '$PACKAGE_VERSION' to become available on pub.dev..."
+echo "Max attempts: $MAX_ATTEMPTS, Sleep duration: $SLEEP_DURATION seconds."
+
+for (( i=1; i<=$MAX_ATTEMPTS; i++ )); do
+  # Query the pub.dev API for the specific package version.
+  # The API endpoint is https://pub.dev/api/packages/<package_name>/versions/<version>
+  # A 200 OK status means the version is available.
+  HTTP_STATUS=$(curl -s -o /dev/null -w "%{http_code}" "https://pub.dev/api/packages/$PACKAGE_NAME/versions/$PACKAGE_VERSION")
+
+  if [ "$HTTP_STATUS" -eq 200 ]; then
+    echo "Successfully found '$PACKAGE_NAME' version '$PACKAGE_VERSION' on pub.dev (HTTP status: $HTTP_STATUS)."
+    exit 0 # Success
+  else
+    echo "Attempt $i/$MAX_ATTEMPTS: '$PACKAGE_NAME' version '$PACKAGE_VERSION' not yet available (HTTP status: $HTTP_STATUS). Retrying in $SLEEP_DURATION seconds..."
+    sleep "$SLEEP_DURATION"
+  fi
+done
+
+echo "Error: Timed out waiting for '$PACKAGE_NAME' version '$PACKAGE_VERSION' to become available on pub.dev after $MAX_ATTEMPTS attempts."
+exit 1 # Failure 

--- a/.github/workflows/publish-packages.yml
+++ b/.github/workflows/publish-packages.yml
@@ -1,0 +1,304 @@
+name: Publish Reown Flutter Packages
+
+on:
+  workflow_dispatch: # Allows manual triggering
+  push:
+    branches:
+      - main # TODO: Adjust to your release branch, e.g., 'develop' or 'release/**'
+
+permissions:
+  contents: write # Required to commit pubspec.yaml changes back to the repo
+
+jobs:
+  detect-changes:
+    name: Detect Changed Packages
+    runs-on: ubuntu-latest
+    outputs:
+      core_changed: ${{ steps.filter.outputs.core_changed }}
+      sign_changed: ${{ steps.filter.outputs.sign_changed }}
+      appkit_changed: ${{ steps.filter.outputs.appkit_changed }}
+      walletkit_changed: ${{ steps.filter.outputs.walletkit_changed }}
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Identify changed files
+        uses: dorny/paths-filter@v3
+        id: filter
+        with:
+          filters: |
+            core_changed:
+              - 'packages/reown_core/**'
+            sign_changed:
+              - 'packages/reown_sign/**'
+            appkit_changed:
+              - 'packages/reown_appkit/**'
+            walletkit_changed:
+              - 'packages/reown_walletkit/**'
+
+  publish-core:
+    name: Publish reown_core
+    needs: detect-changes
+    if: needs.detect-changes.outputs.core_changed == 'true'
+    runs-on: ubuntu-latest
+    outputs:
+      package_version: ${{ steps.get_version.outputs.version }}
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Set up Flutter
+        uses: subosito/flutter-action@v2
+        with:
+          channel: "stable" # Or your preferred channel
+
+      - name: Install yq
+        run: sudo wget https://github.com/mikefarah/yq/releases/latest/download/yq_linux_amd64 -O /usr/bin/yq && sudo chmod +x /usr/bin/yq
+
+      - name: Get package version from reown_core/pubspec.yaml
+        id: get_version
+        working-directory: packages/reown_core
+        run: echo "version=$(yq e '.version' pubspec.yaml)" >> $GITHUB_OUTPUT
+
+      - name: Configure pub.dev credentials
+        run: |
+          mkdir -p $HOME/.config/dart
+          echo '${{ secrets.PUB_CREDENTIALS }}' > $HOME/.config/dart/pub-credentials.json
+
+      - name: Run generate_files.sh for reown_core
+        working-directory: packages/reown_core
+        run: |
+          chmod +x generate_files.sh
+          sh ./generate_files.sh
+
+      - name: Publish reown_core to pub.dev
+        working-directory: packages/reown_core
+        run: flutter pub publish --force
+
+      - name: Wait for reown_core to be available on pub.dev
+        run: |
+          chmod +x .github/scripts/wait_for_package.sh
+          .github/scripts/wait_for_package.sh reown_core ${{ steps.get_version.outputs.version }}
+
+  publish-sign:
+    name: Publish reown_sign
+    needs: [detect-changes, publish-core]
+    if: needs.detect-changes.outputs.sign_changed == 'true' || needs.detect-changes.outputs.core_changed == 'true'
+    runs-on: ubuntu-latest
+    outputs:
+      package_version: ${{ steps.get_version.outputs.version }}
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0 # Required for git push
+
+      - name: Set up Flutter
+        uses: subosito/flutter-action@v2
+        with:
+          channel: "stable"
+
+      - name: Install yq
+        run: sudo wget https://github.com/mikefarah/yq/releases/latest/download/yq_linux_amd64 -O /usr/bin/yq && sudo chmod +x /usr/bin/yq
+
+      - name: Update reown_core dependency in reown_sign/pubspec.yaml
+        if: needs.detect-changes.outputs.core_changed == 'true' && needs.publish-core.outputs.package_version != ''
+        working-directory: packages/reown_sign
+        run: |
+          CORE_VERSION=${{ needs.publish-core.outputs.package_version }}
+          echo "Updating reown_core dependency to ^$CORE_VERSION in reown_sign/pubspec.yaml"
+          yq e '.dependencies.reown_core = "^" + env(CORE_VERSION)' -i pubspec.yaml
+
+      - name: Commit and push pubspec.yaml changes for reown_sign
+        if: needs.detect-changes.outputs.core_changed == 'true' && needs.publish-core.outputs.package_version != ''
+        run: |
+          git config --global user.name 'github-actions[bot]'
+          git config --global user.email 'github-actions[bot]@users.noreply.github.com'
+          cd packages/reown_sign
+          # Check if there are changes to commit to prevent empty commits
+          if [[ -n $(git status -s pubspec.yaml) ]]; then
+            git add pubspec.yaml
+            git commit -m "ci(reown_sign): Update reown_core to ^${{ needs.publish-core.outputs.package_version }} [skip ci]"
+            git push
+          else
+            echo "No changes to commit in reown_sign/pubspec.yaml"
+          fi
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Get package version from reown_sign/pubspec.yaml
+        id: get_version
+        working-directory: packages/reown_sign
+        run: echo "version=$(yq e '.version' pubspec.yaml)" >> $GITHUB_OUTPUT
+
+      - name: Configure pub.dev credentials
+        run: |
+          mkdir -p $HOME/.config/dart
+          echo '${{ secrets.PUB_CREDENTIALS }}' > $HOME/.config/dart/pub-credentials.json
+
+      - name: Run generate_files.sh for reown_sign
+        working-directory: packages/reown_sign
+        run: |
+          chmod +x generate_files.sh
+          sh ./generate_files.sh
+
+      - name: Publish reown_sign to pub.dev
+        working-directory: packages/reown_sign
+        run: flutter pub publish --force
+
+      - name: Wait for reown_sign to be available on pub.dev
+        run: |
+          chmod +x .github/scripts/wait_for_package.sh
+          .github/scripts/wait_for_package.sh reown_sign ${{ steps.get_version.outputs.version }}
+
+  publish-appkit:
+    name: Publish reown_appkit
+    needs: [detect-changes, publish-core, publish-sign]
+    if: >-
+      needs.detect-changes.outputs.appkit_changed == 'true' ||
+      needs.detect-changes.outputs.sign_changed == 'true' ||
+      needs.detect-changes.outputs.core_changed == 'true'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Set up Flutter
+        uses: subosito/flutter-action@v2
+        with:
+          channel: "stable"
+
+      - name: Install yq
+        run: sudo wget https://github.com/mikefarah/yq/releases/latest/download/yq_linux_amd64 -O /usr/bin/yq && sudo chmod +x /usr/bin/yq
+
+      - name: Update dependencies in reown_appkit/pubspec.yaml
+        if: (needs.detect-changes.outputs.core_changed == 'true' && needs.publish-core.outputs.package_version != '') || (needs.detect-changes.outputs.sign_changed == 'true' && needs.publish-sign.outputs.package_version != '')
+        working-directory: packages/reown_appkit
+        env:
+          CORE_VERSION: ${{ needs.publish-core.outputs.package_version }}
+          SIGN_VERSION: ${{ needs.publish-sign.outputs.package_version }}
+        run: |
+          echo "Updating dependencies in reown_appkit/pubspec.yaml"
+          # Update reown_core if it was published
+          if [[ "${{ needs.detect-changes.outputs.core_changed }}" == 'true' && -n "$CORE_VERSION" ]]; then
+            echo "Setting reown_core to ^$CORE_VERSION"
+            yq e '.dependencies.reown_core = "^" + env(CORE_VERSION)' -i pubspec.yaml
+          fi
+          # Update reown_sign if it was published (either by its own change or due to core change)
+          if [[ ("${{ needs.detect-changes.outputs.sign_changed }}" == 'true' || "${{ needs.detect-changes.outputs.core_changed }}" == 'true') && -n "$SIGN_VERSION" ]]; then
+            echo "Setting reown_sign to ^$SIGN_VERSION"
+            yq e '.dependencies.reown_sign = "^" + env(SIGN_VERSION)' -i pubspec.yaml
+          fi
+
+      - name: Commit and push pubspec.yaml changes for reown_appkit
+        if: (needs.detect-changes.outputs.core_changed == 'true' && needs.publish-core.outputs.package_version != '') || (needs.detect-changes.outputs.sign_changed == 'true' && needs.publish-sign.outputs.package_version != '')
+        run: |
+          git config --global user.name 'github-actions[bot]'
+          git config --global user.email 'github-actions[bot]@users.noreply.github.com'
+          cd packages/reown_appkit
+          if [[ -n $(git status -s pubspec.yaml) ]]; then
+            git add pubspec.yaml
+            git commit -m "ci(reown_appkit): Update core/sign dependencies [skip ci]"
+            git push
+          else
+            echo "No changes to commit in reown_appkit/pubspec.yaml"
+          fi
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Get package version from reown_appkit/pubspec.yaml
+        id: get_version
+        working-directory: packages/reown_appkit
+        run: echo "version=$(yq e '.version' pubspec.yaml)" >> $GITHUB_OUTPUT
+
+      - name: Configure pub.dev credentials
+        run: |
+          mkdir -p $HOME/.config/dart
+          echo '${{ secrets.PUB_CREDENTIALS }}' > $HOME/.config/dart/pub-credentials.json
+
+      - name: Run generate_files.sh for reown_appkit
+        working-directory: packages/reown_appkit
+        run: |
+          chmod +x generate_files.sh
+          sh ./generate_files.sh
+
+      - name: Publish reown_appkit to pub.dev
+        working-directory: packages/reown_appkit
+        run: flutter pub publish --force
+
+  publish-walletkit:
+    name: Publish reown_walletkit
+    needs: [detect-changes, publish-core, publish-sign]
+    if: >-
+      needs.detect-changes.outputs.walletkit_changed == 'true' ||
+      needs.detect-changes.outputs.sign_changed == 'true' ||
+      needs.detect-changes.outputs.core_changed == 'true'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Set up Flutter
+        uses: subosito/flutter-action@v2
+        with:
+          channel: "stable"
+
+      - name: Install yq
+        run: sudo wget https://github.com/mikefarah/yq/releases/latest/download/yq_linux_amd64 -O /usr/bin/yq && sudo chmod +x /usr/bin/yq
+
+      - name: Update dependencies in reown_walletkit/pubspec.yaml
+        if: (needs.detect-changes.outputs.core_changed == 'true' && needs.publish-core.outputs.package_version != '') || (needs.detect-changes.outputs.sign_changed == 'true' && needs.publish-sign.outputs.package_version != '')
+        working-directory: packages/reown_walletkit
+        env:
+          CORE_VERSION: ${{ needs.publish-core.outputs.package_version }}
+          SIGN_VERSION: ${{ needs.publish-sign.outputs.package_version }}
+        run: |
+          echo "Updating dependencies in reown_walletkit/pubspec.yaml"
+          if [[ "${{ needs.detect-changes.outputs.core_changed }}" == 'true' && -n "$CORE_VERSION" ]]; then
+            echo "Setting reown_core to ^$CORE_VERSION"
+            yq e '.dependencies.reown_core = "^" + env(CORE_VERSION)' -i pubspec.yaml
+          fi
+          if [[ ("${{ needs.detect-changes.outputs.sign_changed }}" == 'true' || "${{ needs.detect-changes.outputs.core_changed }}" == 'true') && -n "$SIGN_VERSION" ]]; then
+            echo "Setting reown_sign to ^$SIGN_VERSION"
+            yq e '.dependencies.reown_sign = "^" + env(SIGN_VERSION)' -i pubspec.yaml
+          fi
+
+      - name: Commit and push pubspec.yaml changes for reown_walletkit
+        if: (needs.detect-changes.outputs.core_changed == 'true' && needs.publish-core.outputs.package_version != '') || (needs.detect-changes.outputs.sign_changed == 'true' && needs.publish-sign.outputs.package_version != '')
+        run: |
+          git config --global user.name 'github-actions[bot]'
+          git config --global user.email 'github-actions[bot]@users.noreply.github.com'
+          cd packages/reown_walletkit
+          if [[ -n $(git status -s pubspec.yaml) ]]; then
+            git add pubspec.yaml
+            git commit -m "ci(reown_walletkit): Update core/sign dependencies [skip ci]"
+            git push
+          else
+            echo "No changes to commit in reown_walletkit/pubspec.yaml"
+          fi
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Get package version from reown_walletkit/pubspec.yaml
+        id: get_version
+        working-directory: packages/reown_walletkit
+        run: echo "version=$(yq e '.version' pubspec.yaml)" >> $GITHUB_OUTPUT
+
+      - name: Configure pub.dev credentials
+        run: |
+          mkdir -p $HOME/.config/dart
+          echo '${{ secrets.PUB_CREDENTIALS }}' > $HOME/.config/dart/pub-credentials.json
+
+      - name: Run generate_files.sh for reown_walletkit
+        working-directory: packages/reown_walletkit
+        run: |
+          chmod +x generate_files.sh
+          sh ./generate_files.sh
+
+      - name: Publish reown_walletkit to pub.dev
+        working-directory: packages/reown_walletkit
+        run: flutter pub publish --force

--- a/.github/workflows/publish-packages.yml
+++ b/.github/workflows/publish-packages.yml
@@ -70,6 +70,11 @@ jobs:
         run: |
           chmod +x generate_files.sh
           sh ./generate_files.sh
+      
+      - name: Check Publish Warnings
+        shell: bash
+        run: flutter pub publish --dry-run
+        continue-on-error: false
 
       - name: Publish reown_core to pub.dev
         working-directory: packages/reown_core
@@ -141,6 +146,11 @@ jobs:
         run: |
           chmod +x generate_files.sh
           sh ./generate_files.sh
+
+      - name: Check Publish Warnings
+        shell: bash
+        run: flutter pub publish --dry-run
+        continue-on-error: false
 
       - name: Publish reown_sign to pub.dev
         working-directory: packages/reown_sign
@@ -224,6 +234,11 @@ jobs:
           chmod +x generate_files.sh
           sh ./generate_files.sh
 
+      - name: Check Publish Warnings
+        shell: bash
+        run: flutter pub publish --dry-run
+        continue-on-error: false
+
       - name: Publish reown_appkit to pub.dev
         working-directory: packages/reown_appkit
         run: flutter pub publish --force
@@ -298,6 +313,11 @@ jobs:
         run: |
           chmod +x generate_files.sh
           sh ./generate_files.sh
+
+      - name: Check Publish Warnings
+        shell: bash
+        run: flutter pub publish --dry-run
+        continue-on-error: false
 
       - name: Publish reown_walletkit to pub.dev
         working-directory: packages/reown_walletkit


### PR DESCRIPTION
## PR Summary: Automate Flutter Package Publishing with GitHub Actions CI/CD

This PR introduces a GitHub Actions workflow to automate the publishing process for the `reown_core`, `reown_sign`, `reown_appkit`, and `reown_walletkit` Flutter packages. This CI/CD pipeline aims to replace the current manual publishing steps, ensuring consistency, reducing manual effort, and enabling faster releases.

**Key Changes:**

1.  **New GitHub Actions Workflow (`.github/workflows/publish-packages.yml`):**
    *   This workflow orchestrates the entire publishing process.
    *   **Triggers:**
        *   Manually via `workflow_dispatch` from the Actions tab.
        *   Automatically on pushes to a specified branch (currently `main`, **needs configuration**).
    *   **Change Detection:** Uses `dorny/paths-filter` to identify which packages have changed since the last push, determining which packages need to be published.
    *   **Sequential Publishing Logic:**
        *   **`reown_core`**: Published first if changes are detected in `core_changed` path.
        *   **`reown_sign`**: Published after `reown_core` if `sign_changed` or `core_changed` paths have changes.
            *   Automatically updates `reown_sign`'s `pubspec.yaml` to use the newly published `reown_core` version.
            *   Commits the `pubspec.yaml` change back to the repository with `[skip ci]`.
        *   **`reown_appkit` & `reown_walletkit`**: Published after `reown_sign` (and `reown_core`) if their respective paths (`appkit_changed`, `walletkit_changed`) or their upstream dependencies (`core_changed`, `sign_changed`) have changes.
            *   Automatically updates their `pubspec.yaml` files to use the newly published `reown_core` and/or `reown_sign` versions.
            *   Commits `pubspec.yaml` changes back to the repository with `[skip ci]`.
    *   **Pre-publish Script:** Runs the `generate_files.sh` script (expected in each package directory) before publishing each package. This handles `flutter pub get` and any necessary code generation.
    *   **Pub.dev Synchronization:** Waits for each package to become available on `pub.dev` after publishing before proceeding to dependent packages, using a helper script.
    *   **Credentials:** Uses a GitHub secret (`PUB_CREDENTIALS`) for authentication with `pub.dev`.
    *   **Versioning:** Assumes package versions in `pubspec.yaml` files are incremented *before* the workflow runs. The workflow reads these versions for publishing and dependency updates.

2.  **Helper Script (`.github/scripts/wait_for_package.sh`):**
    *   A shell script used by the workflow to poll `pub.dev` and confirm that a package version is live before dependent packages attempt to use it.

**How it Addresses the Manual Process:**

*   **Branch Update:** The workflow checks out the specified branch.
*   **Ordered Publishing:**
    *   Handles the conditional logic for "AppKit/WalletKit only" vs. "Core and Sign SDKs" by checking changed paths.
    *   Automates `cd` into package directories.
    *   Executes `generate_files.sh`.
    *   Runs `flutter pub publish --force`.
    *   Includes waiting periods for `pub.dev` propagation.
    *   Updates `pubspec.yaml` dependencies automatically.

**Actionable Configuration Required:**

1.  **Set `PUB_CREDENTIALS` Secret:**
    *   In your GitHub repository, go to `Settings` > `Secrets and variables` > `Actions`.
    *   Create a new repository secret named `PUB_CREDENTIALS`.
    *   The value should be the JSON content of your `~/.pub-cache/credentials.json` file (or `$HOME/.config/dart/pub-credentials.json` on Linux/macOS, `%APPDATA%/dart/pub-credentials.json` on Windows) after you've locally authenticated with `dart pub login` or `flutter pub login`.
    *   Example content:
        ```json
        {
          "accessToken":"...",
          "refreshToken":"...",
          "tokenEndpoint":"https://accounts.google.com/o/oauth2/token",
          "scopes":["openid","https://www.googleapis.com/auth/userinfo.email"],
          "expiration":160...
        }
        ```

2.  **Adjust Trigger Branch:**
    *   Open `.github/workflows/publish-packages.yml`.
    *   On line `6`, change `main` in `branches: - main` to your primary development or release branch (e.g., `develop`, `release/*`).

3.  **Verify `generate_files.sh` Scripts:**
    *   Ensure a `generate_files.sh` script exists and is executable in each package directory:
        *   `packages/reown_core/generate_files.sh`
        *   `packages/reown_sign/generate_files.sh`
        *   `packages/reown_appkit/generate_files.sh`
        *   `packages/reown_walletkit/generate_files.sh`
    *   Confirm these scripts correctly run `flutter pub get` (especially after potential `pubspec.yaml` updates by the workflow) and perform all necessary file generation steps.

**Testing Recommendations:**

*   Before merging to your main release branch, thoroughly test this workflow:
    *   Trigger it manually (`workflow_dispatch`) on a test branch.
    *   Make changes to individual packages and combinations of packages (e.g., only AppKit, only Core, Core + Sign) and push to the test branch to observe the workflow's behavior.
    *   Verify that packages are published in the correct order and that `pubspec.yaml` files are updated and committed as expected.
    *   Confirm that the correct versions are published to `pub.dev`.
*   Consider publishing to a private or test `pub.dev` repository first if available, or use test package names during initial testing if concerned about publishing incomplete versions.

This automation should significantly streamline the release process.