### PR TITLE
[Bugfix] Disabling installed wallets not working

### DIFF
--- a/packages/reown_appkit/CHANGELOG.md
+++ b/packages/reown_appkit/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 1.4.6
+
+- Fix an issue where disabling installed wallets wasn't working
+
 ## 1.4.5
 
 - General security improvements and verify API V4 readiness

--- a/packages/reown_appkit/lib/modal/services/explorer_service/explorer_service.dart
+++ b/packages/reown_appkit/lib/modal/services/explorer_service/explorer_service.dart
@@ -121,7 +121,9 @@ class ExplorerService implements IExplorerService {
 
     // TODO ideally we should call this at every opening to be able to detect newly installed wallets.
     final nativeData = await _fetchNativeAppData();
-    final installed = await nativeData.getInstalledApps();
+    final installed = (await nativeData.getInstalledApps())
+        .where((e) => !(excludedWalletIds ?? {}).contains(e.id))
+        .toList();
     _installedWalletIds = Set<String>.from(installed.map((e) => e.id));
 
     await _fetchInitialWallets();
@@ -565,7 +567,8 @@ extension on List<AppKitModalWalletListing> {
 
 extension on List<ReownAppKitModalWalletInfo> {
   List<ReownAppKitModalWalletInfo> sortByFeaturedIds(
-      Set<String>? featuredWalletIds) {
+    Set<String>? featuredWalletIds,
+  ) {
     Map<String, dynamic> sortedMap = {};
     final auxList = List<ReownAppKitModalWalletInfo>.from(this);
 

--- a/packages/reown_appkit/lib/version.dart
+++ b/packages/reown_appkit/lib/version.dart
@@ -1,2 +1,2 @@
 // Generated code. Do not modify.
-const packageVersion = '1.4.5';
+const packageVersion = '1.4.6';

--- a/packages/reown_appkit/pubspec.yaml
+++ b/packages/reown_appkit/pubspec.yaml
@@ -29,10 +29,8 @@ dependencies:
   pinenacl: ^0.6.0
   plugin_platform_interface: ^2.1.8
   qr_flutter_wc: ^0.0.3
-  reown_core:
-    path: ../reown_core/
-  reown_sign:
-    path: ../reown_sign/
+  reown_core: ^1.1.6
+  reown_sign: ^1.1.7
   shimmer: ^3.0.0
   synchronized: ^3.3.0+3
   web_socket_channel: ^3.0.1

--- a/packages/reown_appkit/pubspec.yaml
+++ b/packages/reown_appkit/pubspec.yaml
@@ -1,6 +1,6 @@
 name: reown_appkit
 description: "Reown is the onchain UX platform that provides toolkits built on top of the WalletConnect Network"
-version: 1.4.5
+version: 1.4.6
 homepage: https://github.com/reown-com/reown_flutter
 repository: https://github.com/reown-com/reown_flutter/tree/master/packages/reown_appkit
 documentation: https://docs.reown.com/appkit/flutter/core/installation

--- a/packages/reown_sign/pubspec.yaml
+++ b/packages/reown_sign/pubspec.yaml
@@ -15,8 +15,7 @@ dependencies:
   freezed_annotation: ^2.4.4
   http: ^1.2.2
   pointycastle: ^3.9.1
-  reown_core:
-    path: ../reown_core/
+  reown_core: ^1.1.6
   web3dart: ^2.7.3
 
 dev_dependencies:

--- a/packages/reown_walletkit/pubspec.yaml
+++ b/packages/reown_walletkit/pubspec.yaml
@@ -12,12 +12,9 @@ dependencies:
   event: ^3.1.0
   flutter:
     sdk: flutter
-  reown_core:
-    path: ../reown_core/
-  reown_sign:
-    path: ../reown_sign/
-  reown_yttrium:
-    path: ../reown_yttrium/
+  reown_core: ^1.1.6
+  reown_sign: ^1.1.7
+  reown_yttrium: ^0.0.1
 
 
 dev_dependencies:


### PR DESCRIPTION
# Description

The disabling wallets mechanism wasn't taking installed wallets into consideration

Resolves https://github.com/reown-com/reown_flutter/issues/197

## Due Dilligence

* [ ] Breaking change
* [ ] Requires a documentation update