### PR TITLE
[reown_pos] Binance fix

### DIFF
--- a/packages/reown_pos/lib/reown_pos_impl.dart
+++ b/packages/reown_pos/lib/reown_pos_impl.dart
@@ -376,16 +376,19 @@ extension _SignEventListeners on ReownPos {
 
 extension _PrivateMembers on ReownPos {
   void _configurePosNamespaces() {
+    final tokenNamespaces = _configuredTokens.getNamespaces();
     for (var supportedNamespace in _supportedNamespaces) {
-      final namespace = supportedNamespace.name;
-      final chains = _configuredTokens.getChainsByNamespace(namespace);
-      final methods = supportedNamespace.methods;
-      final events = supportedNamespace.events;
-      _posNamespaces[namespace] = RequiredNamespace(
-        chains: chains,
-        methods: methods,
-        events: events,
-      );
+      if (tokenNamespaces.contains(supportedNamespace.name)) {
+        final namespace = supportedNamespace.name;
+        final chains = _configuredTokens.getChainsByNamespace(namespace);
+        final methods = supportedNamespace.methods;
+        final events = supportedNamespace.events;
+        _posNamespaces[namespace] = RequiredNamespace(
+          chains: chains,
+          methods: methods,
+          events: events,
+        );
+      }
     }
 
     if (_supportedNamespaces.isNotEmpty) {

--- a/packages/reown_pos/lib/utils/extensions.dart
+++ b/packages/reown_pos/lib/utils/extensions.dart
@@ -99,6 +99,12 @@ extension ListTokenExtension on List<PosToken> {
       return supportedNamespaces.contains(ns) == false;
     });
   }
+
+  List<String> getNamespaces() {
+    return map((e) {
+      return NamespaceUtils.getNamespaceFromChain(e.network.chainId);
+    }).toList();
+  }
 }
 
 extension ListSupportedNamespaceExtension on List<SupportedNamespace> {


### PR DESCRIPTION
# Description

Binance Wallet is rejecting the whole session if any namespace has empty chains

```
JsonRpcError(code: 5100, message: Chains must not be empty)
```

## Due Dilligence

* [ ] Breaking change
* [ ] Requires a documentation update