### PR TITLE
ci(publish): add walletconnect_pay and fix workflow dependencies

### DIFF
--- a/.claude/commands/commit-and-push.md
+++ b/.claude/commands/commit-and-push.md
@@ -4,20 +4,24 @@ Please perform the following tasks:
 
 1. **Check current git status** - Review all modified files and understand what changes have been made
 
-2. **Create meaningful commit** - Stage appropriate files and create a commit with a clear, descriptive message following the project's conventions
+2. **Evaluate current branch** - If current branch is `develop` create a new branch out of it, bring the changes to the new branch.
 
-3. **Push to remote** - Push your commits to the appropriate branch
+3. **Create meaningful commit** - Stage appropriate files and create a commit with a clear, descriptive message following the project's conventions
 
-4. **Check for PR feedback** - Review any open pull requests for:
+4. **Push to remote** - Push your commits to the appropriate branch
+
+5. **Check for PR feedback** - Review any open pull requests for:
    - Comments from reviewers
    - Change requests
    - CI/CD pipeline status
    - Merge conflicts
 
-5. **Plan follow-up actions** - Based on any feedback found:
+6. **Plan follow-up actions** - Based on any feedback found:
    - Create a todo list for addressing review comments
    - Identify any blocking issues
    - Note any questions to ask the team
+
+7. No need to ask permissions for git commands
 
 Remember to:
 - Follow the commit message format used in this repository

--- a/.github/workflows/publish-packages.yml
+++ b/.github/workflows/publish-packages.yml
@@ -59,6 +59,14 @@ on:
         options:
           - "true"
           - "false"
+      walletconnect_pay:
+        description: "Publish WalletConnect Pay?"
+        required: false
+        default: "false"
+        type: choice
+        options:
+          - "true"
+          - "false"
 
 permissions:
   contents: write # Required to commit pubspec.yaml changes back to the repo
@@ -94,7 +102,7 @@ jobs:
 
   publish-core:
     name: Publish reown_core
-    needs: [create-branch]
+    needs: [create-branch, publish-yttrium]
     runs-on: ubuntu-latest
     outputs:
       package_version: ${{ steps.get_version.outputs.version }}
@@ -121,6 +129,31 @@ jobs:
       - name: Install yq
         if: github.event.inputs.core == 'true'
         run: sudo wget https://github.com/mikefarah/yq/releases/latest/download/yq_linux_amd64 -O /usr/bin/yq && sudo chmod +x /usr/bin/yq
+
+      - name: Update reown_yttrium dependency in reown_core/pubspec.yaml
+        if: github.event.inputs.core == 'true' && github.event.inputs.yttrium == 'true' && needs.publish-yttrium.outputs.package_version != ''
+        working-directory: packages/reown_core
+        run: |
+          YTTRIUM_VERSION=${{ needs.publish-yttrium.outputs.package_version }}
+          echo "Updating reown_yttrium dependency to ^$YTTRIUM_VERSION in reown_core/pubspec.yaml"
+          yq e ".dependencies.reown_yttrium = \"^$YTTRIUM_VERSION\"" -i pubspec.yaml
+
+      - name: Commit and push pubspec.yaml changes for reown_core
+        if: github.event.inputs.core == 'true' && github.event.inputs.yttrium == 'true' && needs.publish-yttrium.outputs.package_version != ''
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          git config --global user.name 'github-actions[bot]'
+          git config --global user.email 'github-actions[bot]@users.noreply.github.com'
+          cd packages/reown_core
+          # Check if there are changes to commit to prevent empty commits
+          if [[ -n $(git status -s pubspec.yaml) ]]; then
+            git add pubspec.yaml
+            git commit -m "ci(reown_core): Update reown_yttrium to ^${{ needs.publish-yttrium.outputs.package_version }} [skip ci]"
+            git push https://x-access-token:${GITHUB_TOKEN}@github.com/${{ github.repository }} ${{ needs.create-branch.outputs.branch_name }}
+          else
+            echo "No changes to commit in reown_core/pubspec.yaml"
+          fi
 
       - name: Get package version from reown_core/pubspec.yaml
         if: github.event.inputs.core == 'true'
@@ -289,7 +322,7 @@ jobs:
 
   publish-appkit:
     name: Publish reown_appkit
-    needs: [create-branch, publish-core, publish-sign, publish-walletkit]
+    needs: [create-branch, publish-core, publish-sign]
     runs-on: ubuntu-latest
     steps:
       - name: Check if reown_appkit should be published
@@ -391,6 +424,12 @@ jobs:
         working-directory: packages/reown_appkit
         run: flutter pub publish --force
 
+      - name: Wait for reown_appkit to be available on pub.dev
+        if: github.event.inputs.appkit == 'true'
+        run: |
+          chmod +x .github/scripts/wait_for_package.sh
+          .github/scripts/wait_for_package.sh reown_appkit ${{ steps.get_version.outputs.version }}
+
       - name: Post a message in a channel
         uses: slackapi/slack-github-action@v2.1.0
         if: github.event.inputs.appkit == 'true'
@@ -402,7 +441,7 @@ jobs:
 
   publish-walletkit:
     name: Publish reown_walletkit
-    needs: [create-branch, publish-core, publish-sign, publish-yttrium]
+    needs: [create-branch, publish-core, publish-sign, publish-walletconnect-pay]
     runs-on: ubuntu-latest
     steps:
       - name: Check if reown_walletkit should be published
@@ -429,12 +468,12 @@ jobs:
         run: sudo wget https://github.com/mikefarah/yq/releases/latest/download/yq_linux_amd64 -O /usr/bin/yq && sudo chmod +x /usr/bin/yq
 
       - name: Update dependencies in reown_walletkit/pubspec.yaml
-        if: github.event.inputs.walletkit == 'true' && ((github.event.inputs.core == 'true' && needs.publish-core.outputs.package_version != '') || (github.event.inputs.sign == 'true' && needs.publish-sign.outputs.package_version != '') || (github.event.inputs.yttrium == 'true' && needs.publish-yttrium.outputs.package_version != ''))
+        if: github.event.inputs.walletkit == 'true' && ((github.event.inputs.core == 'true' && needs.publish-core.outputs.package_version != '') || (github.event.inputs.sign == 'true' && needs.publish-sign.outputs.package_version != '') || (github.event.inputs.walletconnect_pay == 'true' && needs.publish-walletconnect-pay.outputs.package_version != ''))
         working-directory: packages/reown_walletkit
         env:
           CORE_VERSION: ${{ needs.publish-core.outputs.package_version }}
           SIGN_VERSION: ${{ needs.publish-sign.outputs.package_version }}
-          YTTRIUM_VERSION: ${{ needs.publish-yttrium.outputs.package_version }}
+          WALLETCONNECT_PAY_VERSION: ${{ needs.publish-walletconnect-pay.outputs.package_version }}
         run: |
           echo "Updating dependencies in reown_walletkit/pubspec.yaml"
           if [[ "${{ github.event.inputs.core }}" == 'true' && -n "$CORE_VERSION" ]]; then
@@ -445,13 +484,13 @@ jobs:
             echo "Setting reown_sign to ^$SIGN_VERSION"
             yq e ".dependencies.reown_sign = \"^$SIGN_VERSION\"" -i pubspec.yaml
           fi
-          if [[ "${{ github.event.inputs.yttrium }}" == 'true' && -n "$YTTRIUM_VERSION" ]]; then
-            echo "Setting reown_yttrium to ^$YTTRIUM_VERSION"
-            yq e ".dependencies.reown_yttrium = \"^$YTTRIUM_VERSION\"" -i pubspec.yaml
+          if [[ "${{ github.event.inputs.walletconnect_pay }}" == 'true' && -n "$WALLETCONNECT_PAY_VERSION" ]]; then
+            echo "Setting walletconnect_pay to ^$WALLETCONNECT_PAY_VERSION"
+            yq e ".dependencies.walletconnect_pay = \"^$WALLETCONNECT_PAY_VERSION\"" -i pubspec.yaml
           fi
 
       - name: Commit and push pubspec.yaml changes for reown_walletkit
-        if: github.event.inputs.walletkit == 'true' && ((github.event.inputs.core == 'true' && needs.publish-core.outputs.package_version != '') || (github.event.inputs.sign == 'true' && needs.publish-sign.outputs.package_version != '') || (github.event.inputs.yttrium == 'true' && needs.publish-yttrium.outputs.package_version != ''))
+        if: github.event.inputs.walletkit == 'true' && ((github.event.inputs.core == 'true' && needs.publish-core.outputs.package_version != '') || (github.event.inputs.sign == 'true' && needs.publish-sign.outputs.package_version != '') || (github.event.inputs.walletconnect_pay == 'true' && needs.publish-walletconnect-pay.outputs.package_version != ''))
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
@@ -461,7 +500,7 @@ jobs:
           # Check if there are changes to commit to prevent empty commits
           if [[ -n $(git status -s pubspec.yaml) ]]; then
             git add pubspec.yaml
-            git commit -m "ci(reown_walletkit): Update core/sign/yttrium dependencies [skip ci]"
+            git commit -m "ci(reown_walletkit): Update core/sign/walletconnect_pay dependencies [skip ci]"
             git push https://x-access-token:${GITHUB_TOKEN}@github.com/${{ github.repository }} ${{ needs.create-branch.outputs.branch_name }}
           else
             echo "No changes to commit in reown_walletkit/pubspec.yaml"
@@ -507,6 +546,12 @@ jobs:
         working-directory: packages/reown_walletkit
         run: flutter pub publish --force
 
+      - name: Wait for reown_walletkit to be available on pub.dev
+        if: github.event.inputs.walletkit == 'true'
+        run: |
+          chmod +x .github/scripts/wait_for_package.sh
+          .github/scripts/wait_for_package.sh reown_walletkit ${{ steps.get_version.outputs.version }}
+
       - name: Post a message in a channel
         uses: slackapi/slack-github-action@v2.1.0
         if: github.event.inputs.walletkit == 'true'
@@ -541,6 +586,10 @@ jobs:
         uses: subosito/flutter-action@v2
         with:
           flutter-version: "3.38.3"
+
+      - name: Install yq
+        if: github.event.inputs.yttrium == 'true'
+        run: sudo wget https://github.com/mikefarah/yq/releases/latest/download/yq_linux_amd64 -O /usr/bin/yq && sudo chmod +x /usr/bin/yq
 
       - name: Get package version from reown_yttrium/pubspec.yaml
         if: github.event.inputs.yttrium == 'true'
@@ -623,6 +672,10 @@ jobs:
         with:
           flutter-version: "3.38.3"
 
+      - name: Install yq
+        if: github.event.inputs.cli == 'true'
+        run: sudo wget https://github.com/mikefarah/yq/releases/latest/download/yq_linux_amd64 -O /usr/bin/yq && sudo chmod +x /usr/bin/yq
+
       - name: Get package version from reown_cli/pubspec.yaml
         if: github.event.inputs.cli == 'true'
         id: get_version
@@ -704,6 +757,10 @@ jobs:
         with:
           flutter-version: "3.38.3"
 
+      - name: Install yq
+        if: github.event.inputs.pos == 'true'
+        run: sudo wget https://github.com/mikefarah/yq/releases/latest/download/yq_linux_amd64 -O /usr/bin/yq && sudo chmod +x /usr/bin/yq
+
       - name: Get package version from pos_client/pubspec.yaml
         if: github.event.inputs.pos == 'true'
         id: get_version
@@ -759,6 +816,92 @@ jobs:
           payload: |
             text: "*pos_client*: ^${{ steps.get_version.outputs.version }} has been published: https://pub.dev/packages/pos_client"
 
+  publish-walletconnect-pay:
+    name: Publish walletconnect_pay
+    needs: [create-branch]
+    runs-on: ubuntu-latest
+    outputs:
+      package_version: ${{ steps.get_version.outputs.version }}
+    steps:
+      - name: Check if walletconnect_pay should be published
+        if: github.event.inputs.walletconnect_pay == 'false'
+        run: |
+          echo "Skipping walletconnect_pay publishing because input was false."
+        continue-on-error: false
+
+      - name: Checkout code
+        if: github.event.inputs.walletconnect_pay == 'true'
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ needs.create-branch.outputs.branch_name }}
+          fetch-depth: 0
+
+      - name: Set up Flutter
+        if: github.event.inputs.walletconnect_pay == 'true'
+        uses: subosito/flutter-action@v2
+        with:
+          flutter-version: "3.38.3"
+
+      - name: Install yq
+        if: github.event.inputs.walletconnect_pay == 'true'
+        run: sudo wget https://github.com/mikefarah/yq/releases/latest/download/yq_linux_amd64 -O /usr/bin/yq && sudo chmod +x /usr/bin/yq
+
+      - name: Get package version from walletconnect_pay/pubspec.yaml
+        if: github.event.inputs.walletconnect_pay == 'true'
+        id: get_version
+        working-directory: packages/walletconnect_pay
+        run: echo "version=$(yq e '.version' pubspec.yaml)" >> $GITHUB_OUTPUT
+
+      - name: Configure pub.dev credentials
+        if: github.event.inputs.walletconnect_pay == 'true'
+        run: |
+          mkdir -p $HOME/.config/dart
+          echo '${{ secrets.PUB_CREDENTIALS }}' > $HOME/.config/dart/pub-credentials.json
+
+      - name: Run code generation for walletconnect_pay
+        if: github.event.inputs.walletconnect_pay == 'true'
+        working-directory: packages/walletconnect_pay
+        run: |
+          flutter pub get
+          dart run build_runner build --delete-conflicting-outputs
+
+      - name: Check Publish Warnings
+        if: github.event.inputs.walletconnect_pay == 'true'
+        shell: bash
+        working-directory: packages/walletconnect_pay
+        run: |
+          set -o pipefail
+
+          OUTPUT=$(flutter pub publish --dry-run 2>&1 || true)
+          echo "$OUTPUT"
+
+          if echo "$OUTPUT" | grep -iE "^Error:|validation.*error|validation.*failed"; then
+            echo "❌ Real error(s) detected in pub publish dry-run"
+            exit 1
+          else
+            echo "✅ No real errors, only warnings (e.g. missing CHANGELOG.md)"
+          fi
+
+      - name: Publish walletconnect_pay to pub.dev
+        if: github.event.inputs.walletconnect_pay == 'true'
+        working-directory: packages/walletconnect_pay
+        run: flutter pub publish --force
+
+      - name: Wait for walletconnect_pay to be available on pub.dev
+        if: github.event.inputs.walletconnect_pay == 'true'
+        run: |
+          chmod +x .github/scripts/wait_for_package.sh
+          .github/scripts/wait_for_package.sh walletconnect_pay ${{ steps.get_version.outputs.version }}
+
+      - name: Post a message in a channel
+        uses: slackapi/slack-github-action@v2.1.0
+        if: github.event.inputs.walletconnect_pay == 'true'
+        with:
+          webhook: ${{ secrets.SLACK_WEBHOOK_URL }}
+          webhook-type: incoming-webhook
+          payload: |
+            text: "*walletconnect_pay*: ^${{ steps.get_version.outputs.version }} has been published: https://pub.dev/packages/walletconnect_pay"
+
   create-pull-request:
     name: Create Pull Request
     needs:
@@ -770,9 +913,11 @@ jobs:
         publish-walletkit,
         publish-yttrium,
         publish-cli,
+        publish-pos,
+        publish-walletconnect-pay,
       ]
     runs-on: ubuntu-latest
-    if: always() && (needs.publish-core.result == 'success' || needs.publish-sign.result == 'success' || needs.publish-appkit.result == 'success' || needs.publish-walletkit.result == 'success' || needs.publish-yttrium.result == 'success' || needs.publish-cli.result == 'success')
+    if: always() && (needs.publish-core.result == 'success' || needs.publish-sign.result == 'success' || needs.publish-appkit.result == 'success' || needs.publish-walletkit.result == 'success' || needs.publish-yttrium.result == 'success' || needs.publish-cli.result == 'success' || needs.publish-pos.result == 'success' || needs.publish-walletconnect-pay.result == 'success')
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
@@ -821,6 +966,8 @@ jobs:
             ${{ github.event.inputs.walletkit == 'true' && '- reown_walletkit' || '' }}
             ${{ github.event.inputs.yttrium == 'true' && '- reown_yttrium' || '' }}
             ${{ github.event.inputs.cli == 'true' && '- reown_cli' || '' }}
+            ${{ github.event.inputs.pos == 'true' && '- pos_client' || '' }}
+            ${{ github.event.inputs.walletconnect_pay == 'true' && '- walletconnect_pay' || '' }}
 
             ## Changes
             - Updated package dependencies to latest published versions

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -66,25 +66,31 @@ reown_flutter/
 
 The packages follow a dependency hierarchy:
 
+**Independent packages** (no internal reown dependencies):
+- **reown_yttrium**: Chain abstraction layer (ERC-4337, ERC-7702 support)
+- **walletconnect_pay**: Payment protocol implementation
+- **reown_cli**: Command-line tool
+- **pos_client**: Point of sale SDK
+
+**Dependent chain**:
+
 1. **reown_core** (Foundation)
-   - No internal reown dependencies
+   - Depends on: `reown_yttrium`
    - Provides: networking, cryptography, storage, message serialization
 
 2. **reown_sign** (Protocol Layer)
    - Depends on: `reown_core`
    - Provides: Sign protocol implementation, session management
 
-3. **reown_walletkit** (Wallet Side)
-   - Depends on: `reown_core`, `reown_sign`, `walletconnect_pay`
-   - Provides: Wallet-side WalletConnect functionality
-
-4. **reown_appkit** (DApp Side)
+3. **reown_appkit** (DApp Side)
    - Depends on: `reown_core`, `reown_sign`
    - Provides: Full UI toolkit with modals, QR codes, WebView support
 
-5. **reown_yttrium** (Chain Abstraction)
-   - Early access package for smart account functionality
-   - Provides: ERC-4337, ERC-7702 support
+4. **reown_walletkit** (Wallet Side)
+   - Depends on: `reown_core`, `reown_sign`, `walletconnect_pay`
+   - Provides: Wallet-side WalletConnect functionality
+
+Note: `reown_appkit` and `reown_walletkit` are independent of each other.
 
 ### Package Details
 
@@ -121,6 +127,32 @@ Full-featured UI toolkit:
 - Comprehensive modal components
 - Asset caching (`cached_network_image`)
 - Shimmer loading effects
+
+#### reown_yttrium
+Chain abstraction layer (early access):
+- Smart account functionality (ERC-4337, ERC-7702)
+- Native platform plugins (Android/iOS)
+- `freezed` for immutable models
+- `eth_sig_util_plus` for signature utilities
+
+#### walletconnect_pay
+Payment protocol plugin:
+- Crypto and stablecoin payment acceptance
+- Multi-blockchain network support
+- Native platform plugins (Android/iOS)
+- `freezed` for immutable models
+
+#### reown_cli
+Command-line tool:
+- Flutter project scaffolding with AppKit SDK integration
+- Project generation and setup automation
+
+#### pos_client
+Point of Sale SDK:
+- Cryptocurrency payment acceptance for POS systems
+- QR code generation for payment requests
+- Event-driven architecture
+- Depends on `reown_core` and `reown_sign` at runtime
 
 ## Key Commands
 
@@ -193,13 +225,20 @@ Packages are published via GitHub Actions workflow (`.github/workflows/publish-p
    - Creating PR with updates
 
 **Publishing Order** (due to dependencies):
-1. `reown_core`
-2. `reown_sign` (depends on core)
-3. `reown_yttrium` (independent)
-4. `reown_walletkit` (depends on core, sign, yttrium)
-5. `reown_appkit` (depends on core, sign, walletkit)
-6. `reown_cli` (independent)
-7. `pos_client` (independent)
+
+Independent packages (run in parallel):
+- `reown_yttrium`
+- `walletconnect_pay`
+- `reown_cli`
+- `pos_client`
+
+Dependent chain:
+1. `reown_yttrium` → `reown_core` (core depends on yttrium)
+2. `reown_core` → `reown_sign` (sign depends on core)
+3. `reown_sign` → `reown_appkit` (appkit depends on core, sign)
+4. `reown_sign` + `walletconnect_pay` → `reown_walletkit` (walletkit depends on core, sign, walletconnect_pay)
+
+Note: `reown_appkit` and `reown_walletkit` are independent and can be published in parallel after `reown_sign`.
 
 ## Architecture Overview
 
@@ -331,9 +370,14 @@ Semantic versioning: `MAJOR.MINOR.PATCH`
 ### Publishing Dependencies
 
 Packages must be published in dependency order:
-1. Foundation packages first (`reown_core`)
-2. Protocol packages (`reown_sign`)
-3. Application packages (`reown_walletkit`, `reown_appkit`)
+
+1. Independent packages first (can run in parallel):
+   - `reown_yttrium`, `walletconnect_pay`, `reown_cli`, `pos_client`
+2. Foundation package: `reown_core` (waits for `reown_yttrium`)
+3. Protocol package: `reown_sign` (waits for `reown_core`)
+4. Application packages (can run in parallel after `reown_sign`):
+   - `reown_appkit` (depends on `reown_core`, `reown_sign`)
+   - `reown_walletkit` (depends on `reown_core`, `reown_sign`, `walletconnect_pay`)
 
 The workflow automatically:
 - Updates `pubspec.yaml` with new dependency versions


### PR DESCRIPTION
## Summary

This PR adds the `walletconnect_pay` package to the publish workflow and fixes several issues with the dependency chain and missing steps.

## Changes

### New Package Support
- Added `walletconnect_pay` input option to workflow dispatch
- Added `publish-walletconnect-pay` job with full publishing flow (code generation, dry-run validation, publish, wait for availability, Slack notification)

### Dependency Chain Fixes
- **Fixed `publish-core`**: Now correctly depends on `publish-yttrium` (yttrium is a dependency of core, not walletkit)
- **Fixed `publish-walletkit`**: Now depends on `publish-walletconnect-pay` instead of `publish-yttrium`
- **Fixed `publish-appkit`**: Removed incorrect `publish-walletkit` dependency (appkit and walletkit are independent packages)

### Missing Steps Added
- Added `yq` installation to `publish-yttrium`, `publish-cli`, and `publish-pos` jobs (was causing failures when reading version from pubspec.yaml)
- Added `wait_for_package.sh` step to `publish-appkit` and `publish-walletkit` for consistency with other jobs

### PR Creation Fixes
- Added `publish-pos` to `create-pull-request` job needs and success condition
- Added `pos_client` and `walletconnect_pay` to PR body template

## Dependency Graph

```
Independent (run in parallel):
├── publish-yttrium
├── publish-walletconnect-pay
├── publish-cli
└── publish-pos

Dependent chain:
publish-yttrium
    └── publish-core
            └── publish-sign
                    ├── publish-appkit
                    └── publish-walletkit ← publish-walletconnect-pay
```

## Test Plan

- [ ] Trigger workflow with only `walletconnect_pay` selected - verify it publishes correctly
- [ ] Trigger workflow with `yttrium` + `core` - verify core waits for yttrium and updates dependency version
- [ ] Trigger workflow with `walletconnect_pay` + `walletkit` - verify walletkit waits for walletconnect_pay
- [ ] Verify all jobs have proper `yq` installation and `wait_for_package.sh` steps

🤖 Generated with [Claude Code](https://claude.ai/code)