### PR TITLE
🐛 Use `startsWith` for the `wc://` check in the `UriService`

### DIFF
--- a/packages/reown_appkit/lib/modal/services/uri_service/url_utils.dart
+++ b/packages/reown_appkit/lib/modal/services/uri_service/url_utils.dart
@@ -17,7 +17,7 @@ class UriService extends IUriService {
     }
 
     // If the wallet is just a generic wc:// then it is not installed
-    if (uri.contains('wc://')) {
+    if (uri.startsWith('wc://')) {
       return false;
     }
 


### PR DESCRIPTION
# Description

Use `startsWith` instead of `contains` to only escape `wc://` deeplink from the service.

Resolves https://github.com/reown-com/reown_flutter/issues/329