### PR TITLE
🐛 Check modal open state before calling `Navigator.pop` when closing

### DIFF
--- a/packages/reown_appkit/lib/modal/appkit_modal_impl.dart
+++ b/packages/reown_appkit/lib/modal/appkit_modal_impl.dart
@@ -1401,13 +1401,16 @@ class ReownAppKitModal
   @override
   void closeModal({bool disconnectSession = false}) async {
     _disconnectOnClose = disconnectSession;
-    // If we aren't open, then we can't and shouldn't close
+
+    // If we aren't open, then we can't and shouldn't close.
+    // This is a necessary check to avoid unnecessary navigator pops.
+    if (!_isOpen) {
+      return;
+    }
+
     _close();
     if (_context != null) {
-      final canPop = Navigator.of(_context!, rootNavigator: true).canPop();
-      if (canPop) {
-        Navigator.of(_context!, rootNavigator: true).pop();
-      }
+      Navigator.maybeOf(_context!, rootNavigator: true)?.maybePop();
     }
     _notify();
   }

--- a/packages/reown_appkit/lib/modal/appkit_modal_impl.dart
+++ b/packages/reown_appkit/lib/modal/appkit_modal_impl.dart
@@ -1400,14 +1400,13 @@ class ReownAppKitModal
 
   @override
   void closeModal({bool disconnectSession = false}) async {
-    _disconnectOnClose = disconnectSession;
-
     // If we aren't open, then we can't and shouldn't close.
     // This is a necessary check to avoid unnecessary navigator pops.
     if (!_isOpen) {
       return;
     }
 
+    _disconnectOnClose = disconnectSession;
     _close();
     if (_context != null) {
       Navigator.maybeOf(_context!, rootNavigator: true)?.maybePop();


### PR DESCRIPTION
# Description

Adding `_isOpen` check when calling `Navigator.pop` in `closeModal` to avoid unnecessary navigation changes.

Resolves https://github.com/reown-com/reown_flutter/issues/331