### PR TITLE
Use latest Claude auto-review action

### DIFF
--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -30,7 +30,7 @@ jobs:
           fetch-depth: 0
 
       - name: Claude Review
-        uses: WalletConnect/actions/claude/auto-review@974cce051b8452198a144e0e6c4df4d2328a132c
+        uses: WalletConnect/actions/claude/auto-review@master
         with:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
           project_context: |


### PR DESCRIPTION
# Description

Updates the Claude auto-review workflow to always use the latest version from the master branch instead of a hard-coded commit hash.

## Due Diligence

* [ ] Breaking change
* [ ] Requires a documentation update