### PR TITLE
Enable Claude auto review on PR open

### DIFF
--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -2,7 +2,7 @@ name: Claude Auto Review
 
 on:
   pull_request:
-    types: [ready_for_review]
+    types: [opened, ready_for_review]
     branches: [main, develop]
   issue_comment:
     types: [created]


### PR DESCRIPTION
## Description

Added the 'opened' trigger type to the Claude auto review workflow so that code reviews run automatically when a new PR is created, not just when a draft PR is marked as ready for review.

## How Has This Been Tested?

This is a workflow configuration change that will be tested when the next PR is opened.

## Due Diligence

- [ ] Breaking change
- [ ] Requires a documentation update