### PR TITLE
fix(walletkit): Fix payment form keyboard handling and remove step pills

### DIFF
--- a/packages/reown_walletkit/example/lib/dependencies/walletkit_service.dart
+++ b/packages/reown_walletkit/example/lib/dependencies/walletkit_service.dart
@@ -810,7 +810,6 @@ class WalletKitService implements IWalletKitService {
       MaterialPageRoute(
         builder: (_) => WCPCollectDataWebView(
           collectDataUrl: collectDataUrl,
-          stepper: (1, 2),
         ),
       ),
     );
@@ -850,18 +849,12 @@ class WalletKitService implements IWalletKitService {
   Future<ConfirmPaymentRequest> _showPaymentDetails(
     PaymentOptionsResponse response,
   ) async {
-    (int, int) stepper = (0, 0);
-    final hasCollectDataUrl = response.collectData?.url?.isNotEmpty ?? false;
-    if (hasCollectDataUrl) {
-      stepper = (2, 2);
-    }
     final result = await _bottomSheetHandler.queueBottomSheet(
       widget: WCPPaymentDetailsWidget(
         paymentOptionsResponse: response,
         paymentRequest: _pendingPaymentRequest!,
       ),
       showBackButton: true,
-      stepper: stepper,
     );
 
     if (result is ConfirmPaymentRequest) {

--- a/packages/reown_walletkit/example/lib/walletconnect_pay/wcp_modals/wcp_information_capture/wcp_collect_data_webview.dart
+++ b/packages/reown_walletkit/example/lib/walletconnect_pay/wcp_modals/wcp_information_capture/wcp_collect_data_webview.dart
@@ -1,5 +1,6 @@
 import 'dart:convert';
 
+import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 import 'package:url_launcher/url_launcher.dart';
 import 'package:reown_walletkit_wallet/dependencies/bottom_sheet/i_bottom_sheet_service.dart';
@@ -90,10 +91,85 @@ class _WCPCollectDataWebViewState extends State<WCPCollectDataWebView> {
     })();
   ''';
 
+  // iOS keyboard stabilization for WKWebView:
+  // - Track keyboard inset through visualViewport
+  // - Add bottom padding so content can scroll above keyboard
+  // - Keep focused input visible without smooth-scroll jitter
+  static const _keyboardFixScript = '''
+    (function() {
+      if (window.__wcpKeyboardFix) return;
+      window.__wcpKeyboardFix = true;
+
+      function isTextInput(el) {
+        return el && (el.tagName === 'INPUT' || el.tagName === 'TEXTAREA'
+          || el.tagName === 'SELECT' || el.isContentEditable);
+      }
+
+      function keyboardInset() {
+        if (!window.visualViewport) return 0;
+        var inset = window.innerHeight - window.visualViewport.height
+          - window.visualViewport.offsetTop;
+        return inset > 0 ? inset : 0;
+      }
+
+      function applyKeyboardInset() {
+        var inset = keyboardInset();
+        document.body.style.paddingBottom = inset + 'px';
+      }
+
+      function keepFocusedVisible() {
+        var el = document.activeElement;
+        if (!isTextInput(el)) return;
+        if (!window.visualViewport) {
+          el.scrollIntoView({ behavior: 'auto', block: 'center' });
+          return;
+        }
+
+        var rect = el.getBoundingClientRect();
+        var topPadding = 12;
+        var bottomPadding = 12;
+        var visibleTop = topPadding;
+        var visibleBottom = window.visualViewport.height - bottomPadding;
+        var isOutOfView = rect.top < visibleTop || rect.bottom > visibleBottom;
+
+        if (isOutOfView) {
+          el.scrollIntoView({ behavior: 'auto', block: 'center' });
+        }
+      }
+
+      var rafId = null;
+      function syncLayout() {
+        if (rafId) cancelAnimationFrame(rafId);
+        rafId = requestAnimationFrame(function() {
+          applyKeyboardInset();
+          keepFocusedVisible();
+          rafId = null;
+        });
+      }
+
+      window.addEventListener('resize', syncLayout);
+      if (window.visualViewport) {
+        window.visualViewport.addEventListener('resize', syncLayout);
+        window.visualViewport.addEventListener('scroll', syncLayout);
+      }
+
+      document.addEventListener('focusin', function() {
+        setTimeout(syncLayout, 50);
+        setTimeout(syncLayout, 250);
+      });
+      document.addEventListener('focusout', function() {
+        setTimeout(syncLayout, 50);
+      });
+
+      syncLayout();
+    })();
+  ''';
+
   late final WebViewController _controller;
   bool _isLoading = true;
   bool _didComplete = false;
   String? _loadError;
+  bool get _isIOS => !kIsWeb && defaultTargetPlatform == TargetPlatform.iOS;
 
   @override
   void initState() {
@@ -134,6 +210,9 @@ class _WCPCollectDataWebViewState extends State<WCPCollectDataWebView> {
           onPageFinished: (_) async {
             _setLoading(false);
             await _injectBridge();
+            if (_isIOS) {
+              await _injectKeyboardFix();
+            }
           },
           onWebResourceError: (_) {
             _setLoading(false);
@@ -161,6 +240,13 @@ class _WCPCollectDataWebViewState extends State<WCPCollectDataWebView> {
     if (_loadError != null) return;
     try {
       await _controller.runJavaScript(_bridgeScript);
+    } catch (_) {}
+  }
+
+  Future<void> _injectKeyboardFix() async {
+    if (_loadError != null || !_isIOS) return;
+    try {
+      await _controller.runJavaScript(_keyboardFixScript);
     } catch (_) {}
   }
 
@@ -220,43 +306,44 @@ class _WCPCollectDataWebViewState extends State<WCPCollectDataWebView> {
 
   @override
   Widget build(BuildContext context) {
+    final content = SafeArea(
+      bottom: !_isIOS,
+      child: Column(
+        children: [
+          // Header with close button
+          Padding(
+            padding: const EdgeInsets.symmetric(
+              horizontal: StyleConstants.linear16,
+              vertical: StyleConstants.linear8,
+            ),
+            child: Row(
+              mainAxisAlignment: MainAxisAlignment.end,
+              children: [
+                IconButton(
+                  padding: const EdgeInsets.all(0.0),
+                  visualDensity: VisualDensity.compact,
+                  onPressed: _close,
+                  icon: const Icon(Icons.close_sharp),
+                ),
+              ],
+            ),
+          ),
+          // Content
+          Expanded(child: _buildContent()),
+        ],
+      ),
+    );
+
     return Scaffold(
       backgroundColor: StyleConstants.bgPrimary,
-      resizeToAvoidBottomInset: false,
-      body: SafeArea(
-        child: Column(
-          children: [
-            // Header with close button
-            Padding(
-              padding: const EdgeInsets.symmetric(
-                horizontal: StyleConstants.linear16,
-                vertical: StyleConstants.linear8,
-              ),
-              child: Row(
-                mainAxisAlignment: MainAxisAlignment.end,
-                children: [
-                  IconButton(
-                    padding: const EdgeInsets.all(0.0),
-                    visualDensity: VisualDensity.compact,
-                    onPressed: _close,
-                    icon: const Icon(Icons.close_sharp),
-                  ),
-                ],
-              ),
-            ),
-            // Content — shrink by keyboard height so bottom fields
-            // remain reachable while avoiding full-scaffold resize jumps.
-            Expanded(
-              child: Padding(
-                padding: EdgeInsets.only(
-                  bottom: MediaQuery.of(context).viewInsets.bottom,
-                ),
-                child: _buildContent(),
-              ),
-            ),
-          ],
-        ),
-      ),
+      resizeToAvoidBottomInset: !_isIOS,
+      body: _isIOS
+          ? MediaQuery.removeViewInsets(
+              context: context,
+              removeBottom: true,
+              child: content,
+            )
+          : content,
     );
   }
 

--- a/packages/reown_walletkit/example/lib/walletconnect_pay/wcp_modals/wcp_information_capture/wcp_collect_data_webview.dart
+++ b/packages/reown_walletkit/example/lib/walletconnect_pay/wcp_modals/wcp_information_capture/wcp_collect_data_webview.dart
@@ -12,11 +12,9 @@ class WCPCollectDataWebView extends StatefulWidget {
     super.key,
     required this.collectDataUrl,
     this.prefillData,
-    this.stepper = const (1, 2),
   });
 
   final String collectDataUrl;
-  final (int, int) stepper;
 
   /// Optional data to prefill form fields in the WebView.
   ///
@@ -224,27 +222,19 @@ class _WCPCollectDataWebViewState extends State<WCPCollectDataWebView> {
   Widget build(BuildContext context) {
     return Scaffold(
       backgroundColor: StyleConstants.bgPrimary,
-      resizeToAvoidBottomInset: true,
+      resizeToAvoidBottomInset: false,
       body: SafeArea(
         child: Column(
           children: [
-            // Header with stepper and close button
+            // Header with close button
             Padding(
               padding: const EdgeInsets.symmetric(
                 horizontal: StyleConstants.linear16,
                 vertical: StyleConstants.linear8,
               ),
               child: Row(
-                mainAxisAlignment: MainAxisAlignment.spaceBetween,
+                mainAxisAlignment: MainAxisAlignment.end,
                 children: [
-                  const SizedBox(width: 40.0),
-                  if (widget.stepper.$1 > 0 && widget.stepper.$2 > 0)
-                    WCPStepsIndicator(
-                      currentStep: widget.stepper.$1,
-                      totalSteps: widget.stepper.$2,
-                    )
-                  else
-                    const SizedBox(width: 40.0),
                   IconButton(
                     padding: const EdgeInsets.all(0.0),
                     visualDensity: VisualDensity.compact,
@@ -254,8 +244,16 @@ class _WCPCollectDataWebViewState extends State<WCPCollectDataWebView> {
                 ],
               ),
             ),
-            // Content
-            Expanded(child: _buildContent()),
+            // Content — shrink by keyboard height so bottom fields
+            // remain reachable while avoiding full-scaffold resize jumps.
+            Expanded(
+              child: Padding(
+                padding: EdgeInsets.only(
+                  bottom: MediaQuery.of(context).viewInsets.bottom,
+                ),
+                child: _buildContent(),
+              ),
+            ),
           ],
         ),
       ),


### PR DESCRIPTION
## Description

Fixes three issues in the WalletKit payment flow webview:

1. **Keyboard whitespace glitch**: Changed keyboard handling from full-scaffold resize to manual padding on content area, eliminating layout jumps when switching between form fields (DOB to Full Name).

2. **Country dropdown glitch**: The dropdown now works smoothly without the layout jumping when the keyboard dismisses.

3. **Bottom field accessibility**: Added keyboard height padding to ensure the webview content is scrollable and bottom form fields remain reachable.

4. **Removed step pills**: Removed the step indicator from the form header for a cleaner UI. Also removed stepper state from the payment details bottom sheet for consistency.

## How Has This Been Tested?

- Verified form scrolling with keyboard open — fields are now reachable
- Tested switching between DOB and Full Name fields — no whitespace artifacts
- Tested Place of Birth country dropdown — opens smoothly without layout glitches
- Confirmed step pills are no longer visible in the form header

## Due Diligence

- [ ] Breaking change
- [ ] Requires a documentation update