### PR TITLE
Bump reown_appkit to 1.8.3

### DIFF
--- a/packages/reown_appkit/CHANGELOG.md
+++ b/packages/reown_appkit/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 1.8.3
+
+- Enabled Coinbase exchange in Deposit With Exchange flow
+
 ## 1.8.2
 
 - Improved deposit-exchange flow

--- a/packages/reown_appkit/lib/version.dart
+++ b/packages/reown_appkit/lib/version.dart
@@ -1,2 +1,2 @@
 // Generated code. Do not modify.
-const packageVersion = '1.8.2';
+const packageVersion = '1.8.3';

--- a/packages/reown_appkit/pubspec.yaml
+++ b/packages/reown_appkit/pubspec.yaml
@@ -1,6 +1,6 @@
 name: reown_appkit
 description: "Reown is the onchain UX platform that provides toolkits built on top of the WalletConnect Network"
-version: 1.8.2
+version: 1.8.3
 homepage: https://github.com/reown-com/reown_flutter
 repository: https://github.com/reown-com/reown_flutter/tree/master/packages/reown_appkit
 documentation: https://docs.reown.com/appkit/flutter/core/installation


### PR DESCRIPTION
## Summary
- Bump `reown_appkit` version from 1.8.2 to 1.8.3
- Updated `pubspec.yaml`, `version.dart`, and `CHANGELOG.md`

## Changelog
- Enabled Coinbase exchange in Deposit With Exchange flow

## Publishing
After merging, run the **Publish Reown Flutter Packages** workflow with only **AppKit = true**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)