### PR TITLE
chore: update iOS CI/CD to use Xcode 26.2

### DIFF
--- a/.github/workflows/release-ios-base.yml
+++ b/.github/workflows/release-ios-base.yml
@@ -100,7 +100,12 @@ jobs:
           flutter build ios $BUILD_ARGS
 
       - name: Set Xcode Version
-        run: sudo xcode-select -s /Applications/Xcode_26.1.app
+        run: |
+          if [ ! -d "/Applications/Xcode_26.2.app/Contents/Developer" ]; then
+            echo "Xcode_26.2 not found at /Applications/Xcode_26.2.app"
+            exit 1
+          fi
+          sudo xcode-select -s /Applications/Xcode_26.2.app/Contents/Developer
 
       - name: Fastlane
         id: fastlane


### PR DESCRIPTION
# Description

Bump Xcode version from 26.1 to 26.2 in the iOS release workflow and add an existence check. This ensures compliance with Apple's requirement that all app submissions use iOS 26 SDK starting April 28, 2026.

The change updates `.github/workflows/release-ios-base.yml` to:
- Pin to Xcode 26.2 (up from 26.1)
- Add a path validation check that fails fast with clear error messaging if Xcode is unavailable on the runner

## How Has This Been Tested?

This change can be verified by:
1. Manually triggering the `release-appkit` or `release-walletkit` workflow
2. Confirming the "Set Xcode Version" step completes successfully
3. Checking that TestFlight upload completes without Apple SDK rejection warnings

## Due Diligence

- [x] Not a breaking change
- [x] No documentation update required