### PR TITLE
Improve WalletKit request modal UX and approval context

### DIFF
--- a/packages/reown_walletkit/example/ios/Podfile.lock
+++ b/packages/reown_walletkit/example/ios/Podfile.lock
@@ -16,7 +16,7 @@ PODS:
     - Flutter
     - YttriumUtilsWrapper (= 0.10.37)
   - Sentry/HybridSDK (8.56.2)
-  - sentry_flutter (9.12.0):
+  - sentry_flutter (9.14.0):
     - Flutter
     - FlutterMacOS
     - Sentry/HybridSDK (= 8.56.2)
@@ -97,7 +97,7 @@ SPEC CHECKSUMS:
   qr_code_scanner: d77f94ecc9abf96d9b9b8fc04ef13f611e5a147a
   reown_yttrium_utils: 9c407bda2e3db1638eed33598cf58fde08fb48e0
   Sentry: b53951377b78e21a734f5dc8318e333dbfc682d7
-  sentry_flutter: 26f4615de8bdc741318397fdc78ba3e4e08df07f
+  sentry_flutter: 841fa2fe08dc72eb95e2320b76e3f751f3400cf5
   shared_preferences_foundation: 7036424c3d8ec98dfe75ff1667cb0cd531ec82bb
   sqflite_darwin: 20b2a3a3b70e43edae938624ce550a3cbf66a3d0
   url_launcher_ios: 7a95fa5b60cc718a708b8f2966718e93db0cef1b

--- a/packages/reown_walletkit/example/lib/dependencies/chain_services/cosmos_service.dart
+++ b/packages/reown_walletkit/example/lib/dependencies/chain_services/cosmos_service.dart
@@ -39,6 +39,7 @@ class CosmosService {
     final keys = GetIt.I<IKeyService>().getKeysForChain(chainSupported.chainId);
     final address = keys[0].address;
 
+    final requester = _walletKit.sessions.get(pRequest.topic)?.peer;
     if (await MethodsUtils.requestApproval(
       '',
       method: pRequest.method,
@@ -46,6 +47,7 @@ class CosmosService {
       address: address,
       transportType: pRequest.transportType.name,
       verifyContext: pRequest.verifyContext,
+      requester: requester,
     )) {
       final publicKey = keys[0].publicKey;
       response = response.copyWith(
@@ -74,6 +76,7 @@ class CosmosService {
     final trxPayload = parameters as Map<String, dynamic>;
     const encoder = JsonEncoder.withIndent('  ');
     final message = encoder.convert(trxPayload);
+    final requester = _walletKit.sessions.get(pRequest.topic)?.peer;
     if (await MethodsUtils.requestApproval(
       message,
       method: pRequest.method,
@@ -81,6 +84,7 @@ class CosmosService {
       address: address,
       transportType: pRequest.transportType.name,
       verifyContext: pRequest.verifyContext,
+      requester: requester,
     )) {
       final publicKey = keys[0].publicKey;
       response = response.copyWith(

--- a/packages/reown_walletkit/example/lib/dependencies/chain_services/evm_service.dart
+++ b/packages/reown_walletkit/example/lib/dependencies/chain_services/evm_service.dart
@@ -16,7 +16,6 @@ import 'package:reown_walletkit_wallet/models/chain_data.dart';
 import 'package:reown_walletkit_wallet/models/chain_metadata.dart';
 import 'package:reown_walletkit_wallet/utils/eth_utils.dart';
 import 'package:reown_walletkit_wallet/utils/methods_utils.dart';
-import 'package:reown_walletkit_wallet/widgets/wc_connection_widget/wc_connection_model.dart';
 
 enum SupportedEVMMethods {
   ethSign,
@@ -131,6 +130,7 @@ class EVMService {
     final message = EthUtils.getUtf8Message(data.toString());
     var response = JsonRpcResponse(id: pRequest.id, jsonrpc: '2.0');
 
+    final requester = _walletKit.sessions.get(pRequest.topic)?.peer;
     if (await MethodsUtils.requestApproval(
       message,
       method: pRequest.method,
@@ -138,6 +138,7 @@ class EVMService {
       address: address,
       transportType: pRequest.transportType.name,
       verifyContext: pRequest.verifyContext,
+      requester: requester,
     )) {
       try {
         final signedTx = signMessage(message);
@@ -178,6 +179,7 @@ class EVMService {
     final message = EthUtils.getUtf8Message(data.toString());
     var response = JsonRpcResponse(id: pRequest.id, jsonrpc: '2.0');
 
+    final requester = _walletKit.sessions.get(pRequest.topic)?.peer;
     if (await MethodsUtils.requestApproval(
       message,
       method: pRequest.method,
@@ -185,6 +187,7 @@ class EVMService {
       address: address,
       transportType: pRequest.transportType.name,
       verifyContext: pRequest.verifyContext,
+      requester: requester,
     )) {
       try {
         final signature = _credentials.signToUint8List(utf8.encode(message));
@@ -220,6 +223,7 @@ class EVMService {
     final data = EthUtils.getDataFromSessionRequest(pRequest);
     var response = JsonRpcResponse(id: pRequest.id, jsonrpc: '2.0');
 
+    final requester = _walletKit.sessions.get(pRequest.topic)?.peer;
     if (await MethodsUtils.requestApproval(
       data,
       method: pRequest.method,
@@ -227,6 +231,7 @@ class EVMService {
       address: address,
       transportType: pRequest.transportType.name,
       verifyContext: pRequest.verifyContext,
+      requester: requester,
     )) {
       try {
         final keys = GetIt.I<IKeyService>().getKeysForChain(
@@ -290,6 +295,7 @@ class EVMService {
     final data = EthUtils.getDataFromSessionRequest(pRequest);
     var response = JsonRpcResponse(id: pRequest.id, jsonrpc: '2.0');
 
+    final requester = _walletKit.sessions.get(pRequest.topic)?.peer;
     if (await MethodsUtils.requestApproval(
       data,
       method: pRequest.method,
@@ -297,6 +303,7 @@ class EVMService {
       address: address,
       transportType: pRequest.transportType.name,
       verifyContext: pRequest.verifyContext,
+      requester: requester,
     )) {
       try {
         final signature = ethSignTypedDataV4(data);
@@ -330,6 +337,7 @@ class EVMService {
 
     var response = JsonRpcResponse(id: pRequest.id, jsonrpc: '2.0');
 
+    final requester = _walletKit.sessions.get(pRequest.topic)?.peer;
     final transaction = await approveTransaction(
       data,
       method: pRequest.method,
@@ -337,6 +345,7 @@ class EVMService {
       address: address,
       transportType: pRequest.transportType.name,
       verifyContext: pRequest.verifyContext,
+      requester: requester,
     );
     if (transaction is Transaction) {
       try {
@@ -386,6 +395,7 @@ class EVMService {
     }
 
     // otherwise we continue with regular flow for eth_sendTransaction
+    final requester = _walletKit.sessions.get(pRequest.topic)?.peer;
     await approveAndSendTransaction(
       pRequest.id,
       txParams,
@@ -393,6 +403,7 @@ class EVMService {
       pRequest.transportType.name,
       pRequest.verifyContext,
       topic,
+      requester: requester,
     );
   }
 
@@ -402,8 +413,9 @@ class EVMService {
     String chainId,
     String transportType,
     VerifyContext? verifyContext,
-    String topic,
-  ) async {
+    String topic, {
+    ConnectionMetadata? requester,
+  }) async {
     var response = JsonRpcResponse(id: requestId, jsonrpc: '2.0');
     final transaction = await approveTransaction(
       txParams,
@@ -411,6 +423,7 @@ class EVMService {
       chainId: chainId,
       transportType: transportType,
       verifyContext: verifyContext,
+      requester: requester,
     );
     if (transaction is Transaction) {
       try {
@@ -471,12 +484,14 @@ class EVMService {
     final pRequest = _walletKit.pendingRequests.getAll().last;
     var response = JsonRpcResponse(id: pRequest.id, jsonrpc: '2.0');
 
+    final requester = _walletKit.sessions.get(pRequest.topic)?.peer;
     if (await MethodsUtils.requestApproval(
       jsonEncode(parameters),
       method: pRequest.method,
       chainId: pRequest.chainId,
       transportType: pRequest.transportType.name,
       verifyContext: pRequest.verifyContext,
+      requester: requester,
     )) {
       try {
         final params = (parameters as List).first as Map<String, dynamic>;
@@ -554,14 +569,15 @@ class EVMService {
 
   Future<dynamic> approveTransaction(
     Map<String, dynamic> tJson, {
-    String? title,
     String? method,
     String? chainId,
     String? address,
     VerifyContext? verifyContext,
     required String transportType,
+    ConnectionMetadata? requester,
   }) async {
     Transaction transaction = tJson.toTransaction();
+    String? gasValue;
 
     final gasPrice = await ethClient.getGasPrice();
     try {
@@ -577,30 +593,24 @@ class EVMService {
         gasPrice: gasPrice,
         maxGas: gasLimit.toInt(),
       );
+      final gasPriceGwei = gasPrice.getInWei ~/ BigInt.from(1000000000);
+      gasValue = '${gasPriceGwei.toString()} GWEI | $gasLimit';
     } on RPCError catch (e) {
       return JsonRpcError(code: e.errorCode, message: e.message);
     }
-
-    final gweiGasPrice = (transaction.gasPrice?.getInWei ?? BigInt.zero) /
-        BigInt.from(1000000000);
 
     const encoder = JsonEncoder.withIndent('  ');
     final trx = encoder.convert(tJson);
 
     if (await MethodsUtils.requestApproval(
       trx,
-      title: title,
       method: method,
       chainId: chainId,
       address: address,
       transportType: transportType,
       verifyContext: verifyContext,
-      extraModels: [
-        WCConnectionModel(
-          title: 'Gas price',
-          elements: ['${gweiGasPrice.toStringAsFixed(2)} GWEI'],
-        ),
-      ],
+      requester: requester,
+      gasValue: gasValue,
     )) {
       return transaction;
     }

--- a/packages/reown_walletkit/example/lib/dependencies/chain_services/kadena_service.dart
+++ b/packages/reown_walletkit/example/lib/dependencies/chain_services/kadena_service.dart
@@ -138,9 +138,13 @@ class KadenaService {
         signingPubKey: keys[0].publicKey,
       );
 
+      final requester = _walletKit.sessions.get(topic)?.peer;
       // Show the sign widget
       final List<bool>? approved = await _bottomSheetService.queueBottomSheet(
-        widget: KadenaRequestWidget(payloads: [payload]),
+        widget: KadenaRequestWidget(
+          requester: requester,
+          payloads: [payload],
+        ),
       );
 
       // If the user approved, sign the request
@@ -190,9 +194,11 @@ class KadenaService {
         chainSupported.chainId,
       );
 
+      final requester = _walletKit.sessions.get(topic)?.peer;
       // Show the sign widget
       final List<bool>? approved = await _bottomSheetService.queueBottomSheet(
         widget: KadenaRequestWidget(
+          requester: requester,
           payloads: [
             ...(quicksignRequest.commandSigDatas
                 .map((e) => PactCommandPayload.fromJson(jsonDecode(e.cmd)))

--- a/packages/reown_walletkit/example/lib/dependencies/chain_services/polkadot_service.dart
+++ b/packages/reown_walletkit/example/lib/dependencies/chain_services/polkadot_service.dart
@@ -86,6 +86,7 @@ class PolkadotService {
         dotkeyPair.ss58Format = 0;
       }
 
+      final requester = _walletKit.sessions.get(pRequest.topic)?.peer;
       if (await MethodsUtils.requestApproval(
         message,
         method: pRequest.method,
@@ -93,6 +94,7 @@ class PolkadotService {
         address: dotkeyPair.address,
         transportType: pRequest.transportType.name,
         verifyContext: pRequest.verifyContext,
+        requester: requester,
       )) {
         final hexSignature = await signMessage(message);
 
@@ -167,6 +169,7 @@ class PolkadotService {
 
     const encoder = JsonEncoder.withIndent('  ');
     final message = encoder.convert(trxPayload);
+    final requester = _walletKit.sessions.get(pRequest.topic)?.peer;
     if (await MethodsUtils.requestApproval(
       message,
       method: pRequest.method,
@@ -174,6 +177,7 @@ class PolkadotService {
       address: dotkeyPair.address,
       transportType: pRequest.transportType.name,
       verifyContext: pRequest.verifyContext,
+      requester: requester,
     )) {
       try {
         // Get info necessary to build an extrinsic

--- a/packages/reown_walletkit/example/lib/dependencies/chain_services/solana_service.dart
+++ b/packages/reown_walletkit/example/lib/dependencies/chain_services/solana_service.dart
@@ -50,12 +50,14 @@ class SolanaService {
       // it's being sent encoded from dapp
       // final base58Decoded = base58.decode(message);
       // final decodedMessage = utf8.decode(base58Decoded);
+      final requester = _walletKit.sessions.get(pRequest.topic)?.peer;
       if (await MethodsUtils.requestApproval(
         message,
         method: pRequest.method,
         chainId: pRequest.chainId,
         address: keyPair.address,
         transportType: pRequest.transportType.name,
+        requester: requester,
       )) {
         final signature = await signMessage(message);
 
@@ -98,13 +100,14 @@ class SolanaService {
 
       final keyPair = await _getKeyPair();
 
+      final requester = _walletKit.sessions.get(pRequest.topic)?.peer;
       if (await MethodsUtils.requestApproval(
-        // Show Approval Modal
         beautifiedTrx,
         method: pRequest.method,
         chainId: pRequest.chainId,
         address: keyPair.address,
         transportType: pRequest.transportType.name,
+        requester: requester,
       )) {
         // Sign the transaction.
         // if params contains `transaction` key we should parse that one and disregard the rest
@@ -177,13 +180,14 @@ class SolanaService {
 
       final keyPair = await _getKeyPair();
 
+      final requester = _walletKit.sessions.get(pRequest.topic)?.peer;
       if (await MethodsUtils.requestApproval(
-        // Show Approval Modal
         beautifiedTrx,
         method: pRequest.method,
         chainId: pRequest.chainId,
         address: keyPair.address,
         transportType: pRequest.transportType.name,
+        requester: requester,
       )) {
         if (params.containsKey('transactions')) {
           final transactions = params['transactions'] as List;

--- a/packages/reown_walletkit/example/lib/dependencies/chain_services/solana_service_2.dart
+++ b/packages/reown_walletkit/example/lib/dependencies/chain_services/solana_service_2.dart
@@ -52,12 +52,14 @@ class SolanaService2 {
       // it's being sent encoded from dapp
       final base58Decoded = base58.decode(message);
       final decodedMessage = utf8.decode(base58Decoded);
+      final requester = _walletKit.sessions.get(pRequest.topic)?.peer;
       if (await MethodsUtils.requestApproval(
         decodedMessage,
         method: pRequest.method,
         chainId: pRequest.chainId,
         address: keyPair.pubkey.toBase58(),
         transportType: pRequest.transportType.name,
+        requester: requester,
       )) {
         final signature = await signMessage(message);
 
@@ -102,13 +104,14 @@ class SolanaService2 {
 
       final keyPair = await _getKeyPair();
 
+      final requester = _walletKit.sessions.get(pRequest.topic)?.peer;
       if (await MethodsUtils.requestApproval(
-        // Show Approval Modal
         beautifiedTrx,
         method: pRequest.method,
         chainId: pRequest.chainId,
         address: keyPair.pubkey.toBase58(),
         transportType: pRequest.transportType.name,
+        requester: requester,
       )) {
         // Sign the transaction.
         // if params contains `transaction` key we should parse that one and disregard the rest, see https://docs.walletconnect.com/advanced/multichain/rpc-reference/solana-rpc#solana_signtransaction
@@ -182,13 +185,14 @@ class SolanaService2 {
 
       final keyPair = await _getKeyPair();
 
+      final requester = _walletKit.sessions.get(pRequest.topic)?.peer;
       if (await MethodsUtils.requestApproval(
-        // Show Approval Modal
         beautifiedTrx,
         method: pRequest.method,
         chainId: pRequest.chainId,
         address: keyPair.pubkey.toBase58(),
         transportType: pRequest.transportType.name,
+        requester: requester,
       )) {
         if (params.containsKey('transactions')) {
           final transactions = params['transactions'] as List;

--- a/packages/reown_walletkit/example/lib/dependencies/chain_services/stacks/stacks_service.dart
+++ b/packages/reown_walletkit/example/lib/dependencies/chain_services/stacks/stacks_service.dart
@@ -88,6 +88,7 @@ class StacksService {
       // );
       // debugPrint('[SampleWallet] getNonce $nonce');
 
+      final requester = _walletKit.sessions.get(pRequest.topic)?.peer;
       if (await MethodsUtils.requestApproval(
         message,
         method: pRequest.method,
@@ -95,6 +96,7 @@ class StacksService {
         address: address,
         transportType: pRequest.transportType.name,
         verifyContext: pRequest.verifyContext,
+        requester: requester,
       )) {
         final signature = await signMessage(message);
         response = response.copyWith(result: {'signature': signature});
@@ -139,6 +141,7 @@ class StacksService {
       final amount = BigInt.parse(params['amount'].toString());
       // final amount = BigInt.parse('1000000');
 
+      final requester = _walletKit.sessions.get(pRequest.topic)?.peer;
       if (await MethodsUtils.requestApproval(
         jsonEncode(params),
         method: pRequest.method,
@@ -146,6 +149,7 @@ class StacksService {
         address: sender,
         transportType: pRequest.transportType.name,
         verifyContext: pRequest.verifyContext,
+        requester: requester,
       )) {
         final keys = GetIt.I<IKeyService>().getKeysForChain(
           chainSupported.chainId,

--- a/packages/reown_walletkit/example/lib/dependencies/chain_services/sui/sui_service.dart
+++ b/packages/reown_walletkit/example/lib/dependencies/chain_services/sui/sui_service.dart
@@ -84,6 +84,7 @@ class SUIService {
       final address = params['address'].toString();
       final message = params['message'].toString();
 
+      final requester = _walletKit.sessions.get(pRequest.topic)?.peer;
       if (await MethodsUtils.requestApproval(
         message,
         method: pRequest.method,
@@ -91,6 +92,7 @@ class SUIService {
         address: address,
         transportType: pRequest.transportType.name,
         verifyContext: pRequest.verifyContext,
+        requester: requester,
       )) {
         final signature = await signMessage(message);
         response = response.copyWith(result: {'signature': signature});
@@ -136,6 +138,7 @@ class SUIService {
     //   "address": "0xd5f647edb77d4fda31d0304506447fb3c92e55aaf77bc5ed4b77c332dd4605fa"
     // }
 
+    final requester = _walletKit.sessions.get(pRequest.topic)?.peer;
     if (await MethodsUtils.requestApproval(
       transaction,
       method: pRequest.method,
@@ -143,6 +146,7 @@ class SUIService {
       address: address,
       transportType: pRequest.transportType.name,
       verifyContext: pRequest.verifyContext,
+      requester: requester,
     )) {
       try {
         final keys = GetIt.I<IKeyService>().getKeysForChain(
@@ -200,6 +204,7 @@ class SUIService {
     //   "address": "0xd5f647edb77d4fda31d0304506447fb3c92e55aaf77bc5ed4b77c332dd4605fa"
     // }
 
+    final requester = _walletKit.sessions.get(pRequest.topic)?.peer;
     if (await MethodsUtils.requestApproval(
       transaction,
       method: pRequest.method,
@@ -207,6 +212,7 @@ class SUIService {
       address: address,
       transportType: pRequest.transportType.name,
       verifyContext: pRequest.verifyContext,
+      requester: requester,
     )) {
       try {
         final keys = GetIt.I<IKeyService>().getKeysForChain(

--- a/packages/reown_walletkit/example/lib/dependencies/chain_services/ton/ton_service.dart
+++ b/packages/reown_walletkit/example/lib/dependencies/chain_services/ton/ton_service.dart
@@ -12,7 +12,6 @@ import 'package:reown_walletkit_wallet/dependencies/key_service/i_key_service.da
 import 'package:reown_walletkit_wallet/models/chain_metadata.dart';
 import 'package:reown_walletkit_wallet/utils/dart_defines.dart';
 import 'package:reown_walletkit_wallet/utils/methods_utils.dart';
-import 'package:reown_walletkit_wallet/widgets/wc_connection_widget/wc_connection_model.dart';
 
 import 'package:reown_yttrium_utils/models/ton.dart';
 
@@ -124,6 +123,7 @@ class TonService {
         address: address ?? '',
         transportType: pRequest.transportType.name,
         verifyContext: pRequest.verifyContext,
+        requester: session?.peer,
       )) {
         final signature = await signMessage(text);
         final timestamp = DateTime.now().millisecondsSinceEpoch ~/ 1000;
@@ -200,21 +200,18 @@ class TonService {
           .toList();
 
       const encoder = JsonEncoder.withIndent('  ');
+      final messagesText = messages
+          .map((m) => encoder.convert(m.toJson()))
+          .join('\n\n');
+      final requester = _walletKit.sessions.get(pRequest.topic)?.peer;
       if (await MethodsUtils.requestApproval(
-        '',
+        messagesText,
         method: pRequest.method,
         chainId: pRequest.chainId,
         address: address,
         transportType: pRequest.transportType.name,
         verifyContext: pRequest.verifyContext,
-        extraModels: messages
-            .map(
-              (m) => WCConnectionModel(
-                title: 'Message',
-                elements: [encoder.convert(m.toJson())],
-              ),
-            )
-            .toList(),
+        requester: requester,
       )) {
         final signature = await _tonClient.sendMessage(
           networkId: chainSupported.chainId,

--- a/packages/reown_walletkit/example/lib/dependencies/chain_services/tron_service.dart
+++ b/packages/reown_walletkit/example/lib/dependencies/chain_services/tron_service.dart
@@ -46,6 +46,7 @@ class TronService {
       final address = params['address'].toString();
       final message = params['message'].toString();
 
+      final requester = _walletKit.sessions.get(pRequest.topic)?.peer;
       if (await MethodsUtils.requestApproval(
         message,
         method: pRequest.method,
@@ -53,6 +54,7 @@ class TronService {
         address: address,
         transportType: pRequest.transportType.name,
         verifyContext: pRequest.verifyContext,
+        requester: requester,
       )) {
         // Convert signature to hex string (r, s, v) → 65 bytes
         final signatureHex = await signMessage(message);
@@ -105,6 +107,7 @@ class TronService {
 
     const encoder = JsonEncoder.withIndent('  ');
     final message = encoder.convert(transactionJson);
+    final requester = _walletKit.sessions.get(pRequest.topic)?.peer;
     if (await MethodsUtils.requestApproval(
       message,
       method: pRequest.method,
@@ -112,6 +115,7 @@ class TronService {
       address: address,
       transportType: pRequest.transportType.name,
       verifyContext: pRequest.verifyContext,
+      requester: requester,
     )) {
       try {
         final keys = GetIt.I<IKeyService>().getKeysForChain(

--- a/packages/reown_walletkit/example/lib/main.dart
+++ b/packages/reown_walletkit/example/lib/main.dart
@@ -26,6 +26,7 @@ import 'package:reown_walletkit_wallet/utils/constants.dart';
 import 'package:reown_walletkit_wallet/utils/dart_defines.dart';
 import 'package:reown_walletkit_wallet/utils/string_constants.dart';
 import 'package:reown_walletkit_wallet/widgets/scan_modal.dart';
+import 'package:toastification/toastification.dart';
 
 final GlobalKey<NavigatorState> navigatorKey = GlobalKey<NavigatorState>();
 
@@ -104,14 +105,16 @@ class _MyAppState extends State<MyApp> {
     return ListenableBuilder(
       listenable: themeProvider,
       builder: (context, _) {
-        return MaterialApp(
-          navigatorKey: navigatorKey,
-          navigatorObservers: [SentryNavigatorObserver()],
-          title: StringConstants.appTitle,
-          theme: AppTheme.light(),
-          darkTheme: AppTheme.dark(),
-          themeMode: themeProvider.themeMode,
-          home: const MyHomePage(),
+        return ToastificationWrapper(
+          child: MaterialApp(
+            navigatorKey: navigatorKey,
+            navigatorObservers: [SentryNavigatorObserver()],
+            title: StringConstants.appTitle,
+            theme: AppTheme.light(),
+            darkTheme: AppTheme.dark(),
+            themeMode: themeProvider.themeMode,
+            home: const MyHomePage(),
+          ),
         );
       },
     );

--- a/packages/reown_walletkit/example/lib/main.dart
+++ b/packages/reown_walletkit/example/lib/main.dart
@@ -54,9 +54,6 @@ Future<void> main() async {
           options.dsn = DartDefines.sentryDSN;
           options.environment = kDebugMode ? 'debug_app' : 'deployed_app';
           options.attachScreenshot = true;
-          // Adds request headers and IP for users,
-          // visit: https://docs.sentry.io/platforms/dart/data-management/data-collected/ for more info
-          options.sendDefaultPii = true;
           // Set tracesSampleRate to 1.0 to capture 100% of transactions for tracing.
           // We recommend adjusting this value in production.
           options.tracesSampleRate = 1.0;
@@ -267,7 +264,8 @@ class _MyHomePageState extends State<MyHomePage> {
 
   Widget _buildHeader(AppColors colors) {
     return Padding(
-      padding: const EdgeInsets.symmetric(horizontal: AppSpacing.s4, vertical: AppSpacing.s3),
+      padding: const EdgeInsets.symmetric(
+          horizontal: AppSpacing.s4, vertical: AppSpacing.s3),
       child: Row(
         mainAxisAlignment: MainAxisAlignment.spaceBetween,
         children: [
@@ -369,35 +367,36 @@ class _MyHomePageState extends State<MyHomePage> {
         highlightColor: Colors.transparent,
       ),
       child: BottomNavigationBar(
-      currentIndex: _selectedIndex,
-      unselectedItemColor: colors.textSecondary,
-      selectedItemColor: colors.backgroundInvert,
-      selectedFontSize: 12.0,
-      unselectedFontSize: 12.0,
-      iconSize: 24.0,
-      showUnselectedLabels: true,
-      type: BottomNavigationBarType.fixed,
-      onTap: (int index) => setState(() => _selectedIndex = index),
-      items: _pageDatas.asMap().entries.map((entry) {
-        final isSelected = entry.key == _selectedIndex;
-        final e = entry.value;
-        return BottomNavigationBarItem(
-          icon: Padding(
-            padding: const EdgeInsets.only(top: AppSpacing.s2, bottom: AppSpacing.s1),
-            child: SvgPicture.asset(
-              e.svgIcon,
-              width: 24.0,
-              height: 24.0,
-              colorFilter: ColorFilter.mode(
-                isSelected ? colors.backgroundInvert : colors.textSecondary,
-                BlendMode.srcIn,
+        currentIndex: _selectedIndex,
+        unselectedItemColor: colors.textSecondary,
+        selectedItemColor: colors.backgroundInvert,
+        selectedFontSize: 12.0,
+        unselectedFontSize: 12.0,
+        iconSize: 24.0,
+        showUnselectedLabels: true,
+        type: BottomNavigationBarType.fixed,
+        onTap: (int index) => setState(() => _selectedIndex = index),
+        items: _pageDatas.asMap().entries.map((entry) {
+          final isSelected = entry.key == _selectedIndex;
+          final e = entry.value;
+          return BottomNavigationBarItem(
+            icon: Padding(
+              padding: const EdgeInsets.only(
+                  top: AppSpacing.s2, bottom: AppSpacing.s1),
+              child: SvgPicture.asset(
+                e.svgIcon,
+                width: 24.0,
+                height: 24.0,
+                colorFilter: ColorFilter.mode(
+                  isSelected ? colors.backgroundInvert : colors.textSecondary,
+                  BlendMode.srcIn,
+                ),
               ),
             ),
-          ),
-          label: e.title,
-        );
-      }).toList(),
-    ),
+            label: e.title,
+          );
+        }).toList(),
+      ),
     );
   }
 }

--- a/packages/reown_walletkit/example/lib/main.dart
+++ b/packages/reown_walletkit/example/lib/main.dart
@@ -110,6 +110,10 @@ class _MyAppState extends State<MyApp> {
             theme: AppTheme.light(),
             darkTheme: AppTheme.dark(),
             themeMode: themeProvider.themeMode,
+            builder: (context, child) => DefaultTextStyle.merge(
+              style: const TextStyle(fontFamily: 'KH Teka'),
+              child: child ?? const SizedBox.shrink(),
+            ),
             home: const MyHomePage(),
           ),
         );

--- a/packages/reown_walletkit/example/lib/pages/app_detail_page.dart
+++ b/packages/reown_walletkit/example/lib/pages/app_detail_page.dart
@@ -167,7 +167,7 @@ class _AppInfoCard extends StatelessWidget {
       width: double.infinity,
       padding: const EdgeInsets.all(AppSpacing.s5),
       decoration: BoxDecoration(
-        color: colors.backgroundSecondary,
+        color: colors.foregroundPrimary,
         borderRadius: BorderRadius.circular(AppSpacing.s5),
       ),
       child: Row(
@@ -236,7 +236,7 @@ class _DetailCard extends StatelessWidget {
       width: double.infinity,
       padding: const EdgeInsets.all(AppSpacing.s5),
       decoration: BoxDecoration(
-        color: colors.backgroundSecondary,
+        color: colors.foregroundPrimary,
         borderRadius: BorderRadius.circular(AppSpacing.s5),
       ),
       child: Column(

--- a/packages/reown_walletkit/example/lib/pages/balances_page.dart
+++ b/packages/reown_walletkit/example/lib/pages/balances_page.dart
@@ -175,14 +175,15 @@ class _BalancesPageState extends State<BalancesPage> {
                       Center(
                         child: Padding(
                           padding: const EdgeInsets.all(AppSpacing.s6),
-                          child: CircularProgressIndicator(color: colors.accent),
+                          child:
+                              CircularProgressIndicator(color: colors.accent),
                         ),
                       )
                     else if (_filteredBalances.isEmpty)
                       Container(
                         height: 64.0,
                         decoration: BoxDecoration(
-                          color: colors.backgroundSecondary,
+                          color: colors.foregroundPrimary,
                           borderRadius: BorderRadius.circular(20.0),
                         ),
                         alignment: Alignment.center,
@@ -216,7 +217,7 @@ class _BalancesPageState extends State<BalancesPage> {
                           child: Container(
                             height: 64.0,
                             decoration: BoxDecoration(
-                              color: colors.backgroundSecondary,
+                              color: colors.foregroundPrimary,
                               borderRadius: BorderRadius.circular(20.0),
                             ),
                             padding: const EdgeInsets.symmetric(
@@ -248,9 +249,8 @@ class _BalancesPageState extends State<BalancesPage> {
                                           imageUrl: iconUrl,
                                           width: 32.0,
                                           height: 32.0,
-                                          errorWidget:
-                                              (context, url, error) =>
-                                                  const SizedBox.shrink(),
+                                          errorWidget: (context, url, error) =>
+                                              const SizedBox.shrink(),
                                         ),
                                       ),
                                     ),
@@ -376,14 +376,12 @@ class _BalancesFilterWidget extends StatelessWidget {
                     shape: RoundedRectangleBorder(
                       borderRadius: BorderRadius.circular(20.0),
                       side: BorderSide(
-                        color:
-                            isSelected ? colors.accent : colors.inputBorder,
+                        color: isSelected ? colors.accent : colors.inputBorder,
                       ),
                     ),
                     labelStyle: TextStyle(
                       fontSize: 13.0,
-                      color:
-                          isSelected ? colors.accent : colors.textPrimary,
+                      color: isSelected ? colors.accent : colors.textPrimary,
                     ),
                   ),
                 );

--- a/packages/reown_walletkit/example/lib/theme/app_theme.dart
+++ b/packages/reown_walletkit/example/lib/theme/app_theme.dart
@@ -6,9 +6,14 @@ abstract final class AppTheme {
 
   static ThemeData light() {
     const colors = AppColors.light;
+    final textTheme = ThemeData(
+      brightness: Brightness.light,
+    ).textTheme.apply(fontFamily: _fontFamily);
     return ThemeData(
       brightness: Brightness.light,
       fontFamily: _fontFamily,
+      textTheme: textTheme,
+      primaryTextTheme: textTheme,
       colorScheme: ColorScheme.light(
         primary: colors.accent,
         surface: colors.background,
@@ -27,9 +32,14 @@ abstract final class AppTheme {
 
   static ThemeData dark() {
     const colors = AppColors.dark;
+    final textTheme = ThemeData(
+      brightness: Brightness.dark,
+    ).textTheme.apply(fontFamily: _fontFamily);
     return ThemeData(
       brightness: Brightness.dark,
       fontFamily: _fontFamily,
+      textTheme: textTheme,
+      primaryTextTheme: textTheme,
       colorScheme: ColorScheme.dark(
         primary: colors.accent,
         surface: colors.background,

--- a/packages/reown_walletkit/example/lib/theme/app_typography.dart
+++ b/packages/reown_walletkit/example/lib/theme/app_typography.dart
@@ -19,6 +19,13 @@ class AppTypography {
         fontWeight: FontWeight.w500,
       );
 
+  TextStyle get heading6 => TextStyle(
+        color: _c.textPrimary,
+        fontSize: 20.0,
+        fontWeight: FontWeight.w400,
+        letterSpacing: -0.6,
+      );
+
   TextStyle get buttonText => TextStyle(
         color: _c.onAccent,
         fontSize: 16.0,

--- a/packages/reown_walletkit/example/lib/theme/app_typography.dart
+++ b/packages/reown_walletkit/example/lib/theme/app_typography.dart
@@ -21,9 +21,10 @@ class AppTypography {
 
   TextStyle get heading6 => TextStyle(
         color: _c.textPrimary,
+        fontFamily: 'KH Teka',
         fontSize: 20.0,
+        fontStyle: FontStyle.normal,
         fontWeight: FontWeight.w400,
-        letterSpacing: -0.6,
       );
 
   TextStyle get buttonText => TextStyle(

--- a/packages/reown_walletkit/example/lib/utils/methods_utils.dart
+++ b/packages/reown_walletkit/example/lib/utils/methods_utils.dart
@@ -221,7 +221,12 @@ class MethodsUtils {
     bool success = true,
   }) {
     DeepLinkHandler.waiting.value = false;
-    final description = message ?? (success ? 'Return to your dApp' : null);
+    final normalizedMessage = message?.trim();
+    final hasMessage =
+        normalizedMessage != null && normalizedMessage.isNotEmpty;
+    final description = hasMessage
+        ? normalizedMessage
+        : (success ? 'Return to your dApp' : null);
     toastification.show(
       title: Text(title ?? (success ? 'Approved' : 'Error')),
       description: description != null ? Text(description) : null,

--- a/packages/reown_walletkit/example/lib/utils/methods_utils.dart
+++ b/packages/reown_walletkit/example/lib/utils/methods_utils.dart
@@ -4,48 +4,133 @@ import 'package:reown_walletkit/reown_walletkit.dart';
 import 'package:reown_walletkit_wallet/dependencies/bottom_sheet/i_bottom_sheet_service.dart';
 import 'package:reown_walletkit_wallet/dependencies/deep_link_handler.dart';
 import 'package:reown_walletkit_wallet/dependencies/i_walletkit_service.dart';
-import 'package:reown_walletkit_wallet/theme/app_colors.dart';
-import 'package:reown_walletkit_wallet/theme/app_spacing.dart';
-import 'package:reown_walletkit_wallet/widgets/wc_connection_widget/wc_connection_model.dart';
-import 'package:reown_walletkit_wallet/widgets/wc_connection_widget/wc_connection_widget.dart';
-import 'package:reown_walletkit_wallet/widgets/wc_request_widget.dart/wc_request_widget.dart';
+import 'package:reown_walletkit_wallet/models/chain_data.dart';
+import 'package:reown_walletkit_wallet/widgets/wc_request_modal/wc_request_modal.dart';
+import 'package:toastification/toastification.dart';
 
 class MethodsUtils {
   static final walletKit = GetIt.I<IWalletKitService>().walletKit;
 
   static Future<bool> requestApproval(
     String text, {
-    String? title,
     String? method,
     String? chainId,
     String? address,
     required String transportType,
-    List<WCConnectionModel> extraModels = const [],
     VerifyContext? verifyContext,
+    ConnectionMetadata? requester,
+    String? gasValue,
   }) async {
+    final appName = requester?.metadata.name ?? '';
+    final title = _titleForMethod(method, appName);
+    final itemLabel = _itemLabelForMethod(method);
+    final approveLabel = _approveLabelForMethod(method);
+    final chain = chainId != null
+        ? ChainsDataList.allChains
+            .where((c) => c.chainId == chainId)
+            .firstOrNull
+        : null;
+
     final bottomSheetService = GetIt.I<IBottomSheetService>();
     final WCBottomSheetResult rs = (await bottomSheetService.queueBottomSheet(
-          widget: WCRequestWidget(
+          widget: WCRequestModal(
+            requester: requester,
             verifyContext: verifyContext,
-            child: WCConnectionWidget(
-              title: title ?? 'Approve Request',
-              info: [
-                WCConnectionModel(
-                  title: 'Method: $method\n'
-                      'Transport Type: ${transportType.toUpperCase()}\n'
-                      'Chain ID: $chainId\n'
-                      '${address != null ? 'Address: $address' : ''}'
-                      '${text.isNotEmpty ? '\n\nMessage:' : ''}',
-                  elements: [text],
-                ),
-                ...extraModels,
-              ],
+            chain: chain,
+            title: title,
+            summaryRows: _summaryRowsForRequest(
+              text: text,
+              method: method,
+              chainId: chainId,
+              chainName: chain?.name,
+              address: address,
+              gasValue: gasValue,
             ),
+            items: [
+              if (text.isNotEmpty) WCRequestItem(label: itemLabel, value: text),
+            ],
+            approveLabel: approveLabel,
           ),
         )) ??
         WCBottomSheetResult.reject;
 
     return rs != WCBottomSheetResult.reject;
+  }
+
+  static String _titleForMethod(String? method, String appName) {
+    final suffix = appName.isNotEmpty ? ' for $appName' : '';
+    return switch (method) {
+      'personal_sign' || 'eth_sign' => 'Sign a message$suffix',
+      'eth_signTypedData' || 'eth_signTypedData_v4' => 'Sign typed data$suffix',
+      'eth_signTransaction' => 'Sign transaction$suffix',
+      'eth_sendTransaction' => 'Send transaction$suffix',
+      _ => 'Approve request$suffix',
+    };
+  }
+
+  static String _itemLabelForMethod(String? method) {
+    return switch (method) {
+      'personal_sign' || 'eth_sign' => 'Message',
+      'eth_signTypedData' || 'eth_signTypedData_v4' => 'Data',
+      'eth_signTransaction' || 'eth_sendTransaction' => 'Transaction',
+      _ => 'Data',
+    };
+  }
+
+  static List<WCRequestSummaryRow> _summaryRowsForRequest({
+    required String text,
+    String? method,
+    String? chainId,
+    String? chainName,
+    String? address,
+    String? gasValue,
+  }) {
+    final rows = <WCRequestSummaryRow>[
+      if (gasValue != null && gasValue.isNotEmpty)
+        WCRequestSummaryRow(label: 'Gas', value: gasValue),
+    ];
+    if (text.isNotEmpty) {
+      return rows;
+    }
+
+    final methodValue = method ?? 'Unknown';
+    final accountValue =
+        (address != null && address.isNotEmpty) ? address : 'Unknown';
+    final chainValue = (chainName != null && chainName.isNotEmpty)
+        ? chainName
+        : (chainId ?? 'Unknown');
+
+    rows.add(WCRequestSummaryRow(label: 'Method', value: methodValue));
+    rows.add(WCRequestSummaryRow(label: 'Account', value: accountValue));
+    rows.add(WCRequestSummaryRow(label: 'Chain', value: chainValue));
+    return rows;
+  }
+
+  static String _approveLabelForMethod(String? method) {
+    if (method == null) return 'Approve';
+
+    return switch (method) {
+      'wallet_switchEthereumChain' => 'Switch',
+      'wallet_addEthereumChain' => 'Add',
+      'eth_sendTransaction' || 'ton_sendMessage' => 'Send',
+      'personal_sign' ||
+      'eth_sign' ||
+      'eth_signTypedData' ||
+      'eth_signTypedData_v4' ||
+      'eth_signTransaction' ||
+      'ton_signData' =>
+        'Sign',
+      _ => _approveLabelFromMethodName(method),
+    };
+  }
+
+  static String _approveLabelFromMethodName(String method) {
+    final normalized = method.toLowerCase();
+    if (normalized.contains('switch')) return 'Switch';
+    if (normalized.contains('add')) return 'Add';
+    if (normalized.contains('send')) return 'Send';
+    if (normalized.contains('sign')) return 'Sign';
+    return 'Approve';
   }
 
   static void handleRedirect(
@@ -87,36 +172,15 @@ class MethodsUtils {
     String? title,
     String? message,
     bool success = true,
-  }) async {
+  }) {
     DeepLinkHandler.waiting.value = false;
-    await GetIt.I<IBottomSheetService>().queueBottomSheet(
-      closeAfter: success ? 3 : 0,
-      widget: Builder(
-        builder: (context) {
-          final colors = context.colors;
-          return Container(
-            height: 320.0,
-            width: double.infinity,
-            padding: const EdgeInsets.all(AppSpacing.s5),
-            child: Column(
-              children: [
-                Icon(
-                  success
-                      ? Icons.check_circle_sharp
-                      : Icons.error_outline_sharp,
-                  color: success ? colors.success : colors.error,
-                  size: 80.0,
-                ),
-                Text(
-                  title ?? 'Connected',
-                  style: TextStyle(fontWeight: FontWeight.bold),
-                ),
-                Text(message ?? 'You can go back to your dApp now'),
-              ],
-            ),
-          );
-        },
-      ),
+    final description = message ?? (success ? 'Return to your dApp' : null);
+    toastification.show(
+      title: Text(title ?? (success ? 'Approved' : 'Error')),
+      description: description != null ? Text(description) : null,
+      type: success ? ToastificationType.success : ToastificationType.error,
+      autoCloseDuration: Duration(seconds: success ? 3 : 5),
+      alignment: Alignment.bottomCenter,
     );
   }
 }

--- a/packages/reown_walletkit/example/lib/utils/methods_utils.dart
+++ b/packages/reown_walletkit/example/lib/utils/methods_utils.dart
@@ -59,13 +59,60 @@ class MethodsUtils {
 
   static String _titleForMethod(String? method, String appName) {
     final suffix = appName.isNotEmpty ? ' for $appName' : '';
+    if (method == null) return 'Approve request$suffix';
+
     return switch (method) {
       'personal_sign' || 'eth_sign' => 'Sign a message$suffix',
       'eth_signTypedData' || 'eth_signTypedData_v4' => 'Sign typed data$suffix',
       'eth_signTransaction' => 'Sign transaction$suffix',
       'eth_sendTransaction' => 'Send transaction$suffix',
-      _ => 'Approve request$suffix',
+      'solana_signMessage' ||
+      'polkadot_signMessage' ||
+      'stx_signMessage' ||
+      'sui_signPersonalMessage' ||
+      'ton_signData' ||
+      'tron_signMessage' =>
+        'Sign a message$suffix',
+      'solana_signTransaction' ||
+      'solana_signAllTransactions' ||
+      'polkadot_signTransaction' ||
+      'sui_signTransaction' ||
+      'cosmos_signDirect' ||
+      'kadena_sign_v1' ||
+      'kadena_quicksign_v1' ||
+      'tron_signTransaction' =>
+        'Sign transaction$suffix',
+      'sui_signAndExecuteTransaction' ||
+      'ton_sendMessage' ||
+      'stx_transferStx' =>
+        'Send transaction$suffix',
+      'cosmos_getAccounts' || 'kadena_getAccounts_v1' => 'Share account$suffix',
+      _ => _titleFromMethodName(method, suffix),
     };
+  }
+
+  static String _titleFromMethodName(String method, String suffix) {
+    final normalized = method.toLowerCase();
+    if (normalized.contains('signmessage') ||
+        normalized.contains('signpersonal') ||
+        normalized.contains('signdata')) {
+      return 'Sign a message$suffix';
+    }
+    if (normalized.contains('signtransaction') ||
+        normalized.contains('signalltransactions') ||
+        normalized.contains('signdirect') ||
+        normalized.contains('quicksign')) {
+      return 'Sign transaction$suffix';
+    }
+    if (normalized.contains('send') ||
+        normalized.contains('execute') ||
+        normalized.contains('transfer')) {
+      return 'Send transaction$suffix';
+    }
+    if (normalized.contains('getaccounts')) {
+      return 'Share account$suffix';
+    }
+    return 'Approve request$suffix';
   }
 
   static String _itemLabelForMethod(String? method) {

--- a/packages/reown_walletkit/example/lib/widgets/kadena_request_widget/kadena_request_widget.dart
+++ b/packages/reown_walletkit/example/lib/widgets/kadena_request_widget/kadena_request_widget.dart
@@ -4,10 +4,10 @@ import 'package:flutter/material.dart';
 import 'package:kadena_dart_sdk/kadena_dart_sdk.dart';
 import 'package:reown_walletkit/reown_walletkit.dart';
 import 'package:reown_walletkit_wallet/theme/app_colors.dart';
-import 'package:reown_walletkit_wallet/theme/app_radius.dart';
 import 'package:reown_walletkit_wallet/theme/app_spacing.dart';
 import 'package:reown_walletkit_wallet/widgets/custom_button.dart';
 import 'package:reown_walletkit_wallet/widgets/shared/app_icon_widget.dart';
+import 'package:reown_walletkit_wallet/widgets/shared/request_info_row.dart';
 
 /// Multi-step signing modal for Kadena requests.
 ///
@@ -95,22 +95,29 @@ class _KadenaRequestWidgetState extends State<KadenaRequestWidget> {
             child: Column(
               mainAxisSize: MainAxisSize.min,
               children: [
-                _InfoRow(
+                RequestInfoRow(
                   label: 'Pact Command',
                   value: jsonEncode(payload),
                 ),
                 ...caps.map(
-                  (cap) => Padding(
-                    padding: const EdgeInsets.only(top: AppSpacing.s2),
-                    child: _InfoRow(
-                      label: cap.name as String,
-                      value: (cap.args as List).isEmpty
-                          ? '—'
-                          : (cap.args as List)
-                              .map((a) => a.toString())
-                              .join(', '),
-                    ),
-                  ),
+                  (cap) {
+                    final dynamic rawName = cap.name;
+                    final String label = rawName?.toString() ?? 'Unknown';
+                    final dynamic rawArgs = cap.args;
+                    final List<dynamic> argsList =
+                        rawArgs is List ? rawArgs : const [];
+                    final String value = argsList.isEmpty
+                        ? '—'
+                        : argsList.map((a) => a.toString()).join(', ');
+
+                    return Padding(
+                      padding: const EdgeInsets.only(top: AppSpacing.s2),
+                      child: RequestInfoRow(
+                        label: label,
+                        value: value,
+                      ),
+                    );
+                  },
                 ),
               ],
             ),
@@ -149,53 +156,6 @@ class _KadenaRequestWidgetState extends State<KadenaRequestWidget> {
           ],
         ),
       ],
-    );
-  }
-}
-
-class _InfoRow extends StatelessWidget {
-  const _InfoRow({required this.label, required this.value});
-
-  final String label;
-  final String value;
-
-  @override
-  Widget build(BuildContext context) {
-    final colors = context.colors;
-
-    return Container(
-      width: double.infinity,
-      decoration: BoxDecoration(
-        color: colors.foregroundPrimary,
-        borderRadius: BorderRadius.circular(AppRadius.md),
-      ),
-      padding: const EdgeInsets.all(AppSpacing.s5),
-      child: Column(
-        crossAxisAlignment: CrossAxisAlignment.start,
-        children: [
-          Text(
-            label,
-            style: TextStyle(
-              color: colors.textTertiary,
-              fontSize: 16.0,
-              fontWeight: FontWeight.w400,
-              letterSpacing: -0.16,
-              height: 18.0 / 16.0,
-            ),
-          ),
-          const SizedBox(height: AppSpacing.s2),
-          Text(
-            value,
-            style: TextStyle(
-              color: colors.textPrimary,
-              fontSize: 16.0,
-              fontWeight: FontWeight.w400,
-              letterSpacing: -0.16,
-              height: 18.0 / 16.0,
-            ),
-          ),
-        ],
-      ),
     );
   }
 }

--- a/packages/reown_walletkit/example/lib/widgets/kadena_request_widget/kadena_request_widget.dart
+++ b/packages/reown_walletkit/example/lib/widgets/kadena_request_widget/kadena_request_widget.dart
@@ -2,103 +2,200 @@ import 'dart:convert';
 
 import 'package:flutter/material.dart';
 import 'package:kadena_dart_sdk/kadena_dart_sdk.dart';
+import 'package:reown_walletkit/reown_walletkit.dart';
+import 'package:reown_walletkit_wallet/theme/app_colors.dart';
+import 'package:reown_walletkit_wallet/theme/app_radius.dart';
 import 'package:reown_walletkit_wallet/theme/app_spacing.dart';
-import 'package:reown_walletkit_wallet/theme/app_typography.dart';
-import 'package:reown_walletkit_wallet/widgets/wc_connection_widget/wc_connection_model.dart';
-import 'package:reown_walletkit_wallet/widgets/wc_connection_widget/wc_connection_widget.dart';
-import 'package:reown_walletkit_wallet/widgets/wc_request_widget.dart/wc_request_widget.dart';
+import 'package:reown_walletkit_wallet/widgets/custom_button.dart';
+import 'package:reown_walletkit_wallet/widgets/shared/app_icon_widget.dart';
 
-/// A widget that takes a list of PactCommandPayloads, and allows the user
-/// to sign each one individually. If there is only one item in the list,
-/// it doesn't show the number of transactions to be signed. Otherwise, it
-/// shows the number of transactions to be signed at the top.
+/// Multi-step signing modal for Kadena requests.
 ///
-/// This widget is used by the KadenaService to sign any kind of request.
+/// Handles both single-payload (kadena_sign_v1) and multi-payload
+/// (kadena_quicksign_v1) flows. The user approves or rejects each
+/// [PactCommandPayload] one at a time.
 ///
-/// This widget is generally displayed using the [BottomSheetService].
-/// It returns a list of booleans. Each boolean represents whether the
-/// user approved the transaction at the same index in the list of
-/// PactCommandPayloads.
-///
-/// For each PactCommandPayload to be signed, the widget itself
-/// displays the code of the PactCommandPayload and the data.
-/// It also shows each [Capability] that is included in the payload.
+/// Returns a [List<bool>] where each entry corresponds to the user's
+/// decision for the payload at the same index.
 class KadenaRequestWidget extends StatefulWidget {
-  const KadenaRequestWidget({super.key, required this.payloads});
+  const KadenaRequestWidget({
+    super.key,
+    this.requester,
+    required this.payloads,
+  });
 
+  final ConnectionMetadata? requester;
   final List<PactCommandPayload> payloads;
 
   @override
-  KadenaRequestWidgetState createState() => KadenaRequestWidgetState();
+  State<KadenaRequestWidget> createState() => _KadenaRequestWidgetState();
 }
 
-class KadenaRequestWidgetState extends State<KadenaRequestWidget> {
+class _KadenaRequestWidgetState extends State<KadenaRequestWidget> {
   int _currentIndex = 0;
   final List<bool> _responses = [];
 
+  bool get _isMultiStep => widget.payloads.length > 1;
+
+  String get _title {
+    final appName = widget.requester?.metadata.name ?? '';
+    final suffix = appName.isNotEmpty ? ' for $appName' : '';
+    if (_isMultiStep) {
+      return 'Sign ${_currentIndex + 1} of ${widget.payloads.length}$suffix';
+    }
+    return 'Sign transaction$suffix';
+  }
+
+  void _onApprove() {
+    _responses.add(true);
+    _advance();
+  }
+
+  void _onReject() {
+    _responses.add(false);
+    _advance();
+  }
+
+  void _advance() {
+    if (_currentIndex < widget.payloads.length - 1) {
+      setState(() => _currentIndex++);
+    } else {
+      Navigator.of(context).pop(_responses);
+    }
+  }
+
   @override
   Widget build(BuildContext context) {
-    final List<WCConnectionModel> capsList = [];
+    final colors = context.colors;
+    final metadata = widget.requester?.metadata;
+    final payload = widget.payloads[_currentIndex];
+    final caps =
+        payload.signers.isNotEmpty ? (payload.signers.first.clist ?? []) : [];
 
-    if (widget.payloads[_currentIndex].signers.isNotEmpty &&
-        widget.payloads[_currentIndex].signers.first.clist != null) {
-      capsList.addAll(
-        widget.payloads[_currentIndex].signers.first.clist!
-            .map(
-              (e) => WCConnectionModel(
-                title: e.name,
-                elements: e.args.map((e) => e.toString()).toList(),
-              ),
-            )
-            .toList(),
-      );
-    }
-
-    final List<Widget> signCounter = [];
-    if (widget.payloads.length > 1) {
-      signCounter.add(
+    return Column(
+      mainAxisSize: MainAxisSize.min,
+      children: [
+        const SizedBox(height: AppSpacing.s2),
+        if (metadata != null)
+          Center(child: AppIcon(metadata: metadata, size: 64.0)),
+        const SizedBox(height: AppSpacing.s3),
         Text(
-          '${_currentIndex + 1} of ${widget.payloads.length}',
-          style: context.textStyles.subtitleText,
+          _title,
+          style: TextStyle(
+            color: colors.textPrimary,
+            fontSize: 20.0,
+            fontWeight: FontWeight.w400,
+            letterSpacing: -0.6,
+          ),
+          textAlign: TextAlign.center,
         ),
-      );
-      signCounter.add(const SizedBox(height: AppSpacing.s5));
-    }
-
-    return WCRequestWidget(
-      onAccept: () {
-        _responses.add(true);
-        _incrementIndex();
-      },
-      onReject: () {
-        _responses.add(false);
-        _incrementIndex();
-      },
-      child: Column(
-        children: [
-          ...signCounter,
-          WCConnectionWidget(
-            title: 'Sign Transaction',
-            info: [
-              WCConnectionModel(
-                title: 'Pact Command',
-                text: jsonEncode(widget.payloads[_currentIndex]),
+        const SizedBox(height: AppSpacing.s5),
+        Flexible(
+          child: SingleChildScrollView(
+            child: Column(
+              mainAxisSize: MainAxisSize.min,
+              children: [
+                _InfoRow(
+                  label: 'Pact Command',
+                  value: jsonEncode(payload),
+                ),
+                ...caps.map(
+                  (cap) => Padding(
+                    padding: const EdgeInsets.only(top: AppSpacing.s2),
+                    child: _InfoRow(
+                      label: cap.name as String,
+                      value: (cap.args as List).isEmpty
+                          ? '—'
+                          : (cap.args as List)
+                              .map((a) => a.toString())
+                              .join(', '),
+                    ),
+                  ),
+                ),
+              ],
+            ),
+          ),
+        ),
+        const SizedBox(height: AppSpacing.s5),
+        Row(
+          children: [
+            CustomButton(
+              onTap: _onReject,
+              style: CustomButtonStyle.outlined,
+              child: Text(
+                'Reject',
+                style: TextStyle(
+                  color: colors.textPrimary,
+                  fontSize: 16.0,
+                  fontWeight: FontWeight.w400,
+                ),
+                textAlign: TextAlign.center,
               ),
-              ...capsList,
-            ],
+            ),
+            const SizedBox(width: AppSpacing.s3),
+            CustomButton(
+              onTap: _onApprove,
+              type: CustomButtonType.normal,
+              child: Text(
+                'Sign',
+                style: TextStyle(
+                  color: colors.onAccent,
+                  fontSize: 16.0,
+                  fontWeight: FontWeight.w400,
+                ),
+                textAlign: TextAlign.center,
+              ),
+            ),
+          ],
+        ),
+      ],
+    );
+  }
+}
+
+class _InfoRow extends StatelessWidget {
+  const _InfoRow({required this.label, required this.value});
+
+  final String label;
+  final String value;
+
+  @override
+  Widget build(BuildContext context) {
+    final colors = context.colors;
+
+    return Container(
+      width: double.infinity,
+      decoration: BoxDecoration(
+        color: colors.foregroundPrimary,
+        borderRadius: BorderRadius.circular(AppRadius.md),
+      ),
+      padding: const EdgeInsets.all(AppSpacing.s5),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Text(
+            label,
+            style: TextStyle(
+              color: colors.textTertiary,
+              fontSize: 16.0,
+              fontWeight: FontWeight.w400,
+              letterSpacing: -0.16,
+              height: 18.0 / 16.0,
+            ),
+          ),
+          const SizedBox(height: AppSpacing.s2),
+          Text(
+            value,
+            style: TextStyle(
+              color: colors.textPrimary,
+              fontSize: 16.0,
+              fontWeight: FontWeight.w400,
+              letterSpacing: -0.16,
+              height: 18.0 / 16.0,
+            ),
           ),
         ],
       ),
     );
-  }
-
-  void _incrementIndex() {
-    if (_currentIndex < widget.payloads.length - 1) {
-      setState(() {
-        _currentIndex++;
-      });
-    } else {
-      Navigator.of(context).pop(_responses);
-    }
   }
 }

--- a/packages/reown_walletkit/example/lib/widgets/session_item.dart
+++ b/packages/reown_walletkit/example/lib/widgets/session_item.dart
@@ -56,10 +56,11 @@ class SessionItem extends StatelessWidget {
     return GestureDetector(
       onTap: onTap,
       child: Container(
-        margin: const EdgeInsets.symmetric(horizontal: AppSpacing.s4, vertical: AppSpacing.s1),
+        margin: const EdgeInsets.symmetric(
+            horizontal: AppSpacing.s4, vertical: AppSpacing.s1),
         padding: const EdgeInsets.all(AppSpacing.s5),
         decoration: BoxDecoration(
-          color: colors.backgroundSecondary,
+          color: colors.foregroundPrimary,
           borderRadius: AppRadius.borderRadiusMd,
         ),
         child: Row(

--- a/packages/reown_walletkit/example/lib/widgets/session_item.dart
+++ b/packages/reown_walletkit/example/lib/widgets/session_item.dart
@@ -72,14 +72,14 @@ class SessionItem extends StatelessWidget {
                 children: [
                   Text(
                     metadata.name,
-                    style: context.textStyles.layerTextStyle2,
+                    style: context.textStyles.wcpTextPrimary,
                     maxLines: 1,
                     overflow: TextOverflow.ellipsis,
                   ),
                   const SizedBox(height: AppSpacing.s05),
                   Text(
                     _cleanUrl(metadata.url),
-                    style: context.textStyles.bodyText,
+                    style: context.textStyles.wcpTextSecondary,
                     maxLines: 1,
                     overflow: TextOverflow.ellipsis,
                   ),

--- a/packages/reown_walletkit/example/lib/widgets/shared/expandable_section.dart
+++ b/packages/reown_walletkit/example/lib/widgets/shared/expandable_section.dart
@@ -41,7 +41,7 @@ class _ExpandableSectionState extends State<ExpandableSection> {
     final colors = context.colors;
     return Container(
       decoration: BoxDecoration(
-        color: colors.backgroundSecondary,
+        color: colors.foregroundPrimary,
         borderRadius: BorderRadius.circular(AppRadius.md),
       ),
       clipBehavior: Clip.hardEdge,

--- a/packages/reown_walletkit/example/lib/widgets/shared/request_info_row.dart
+++ b/packages/reown_walletkit/example/lib/widgets/shared/request_info_row.dart
@@ -1,0 +1,55 @@
+import 'package:flutter/material.dart';
+import 'package:reown_walletkit_wallet/theme/app_colors.dart';
+import 'package:reown_walletkit_wallet/theme/app_radius.dart';
+import 'package:reown_walletkit_wallet/theme/app_spacing.dart';
+
+class RequestInfoRow extends StatelessWidget {
+  const RequestInfoRow({
+    super.key,
+    required this.label,
+    required this.value,
+  });
+
+  final String label;
+  final String value;
+
+  @override
+  Widget build(BuildContext context) {
+    final colors = context.colors;
+
+    return Container(
+      width: double.infinity,
+      decoration: BoxDecoration(
+        color: colors.foregroundPrimary,
+        borderRadius: BorderRadius.circular(AppRadius.md),
+      ),
+      padding: const EdgeInsets.all(AppSpacing.s5),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Text(
+            label,
+            style: TextStyle(
+              color: colors.textTertiary,
+              fontSize: 16.0,
+              fontWeight: FontWeight.w400,
+              letterSpacing: -0.16,
+              height: 18.0 / 16.0,
+            ),
+          ),
+          const SizedBox(height: AppSpacing.s2),
+          Text(
+            value,
+            style: TextStyle(
+              color: colors.textPrimary,
+              fontSize: 16.0,
+              fontWeight: FontWeight.w400,
+              letterSpacing: -0.16,
+              height: 18.0 / 16.0,
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}

--- a/packages/reown_walletkit/example/lib/widgets/wc_connection_request/network_section.dart
+++ b/packages/reown_walletkit/example/lib/widgets/wc_connection_request/network_section.dart
@@ -34,7 +34,7 @@ class NetworkSection extends StatelessWidget {
     if (isSingleChain) {
       return Container(
         decoration: BoxDecoration(
-          color: colors.backgroundSecondary,
+          color: colors.foregroundPrimary,
           borderRadius: BorderRadius.circular(AppRadius.md),
         ),
         padding: const EdgeInsets.symmetric(

--- a/packages/reown_walletkit/example/lib/widgets/wc_connection_request/network_section.dart
+++ b/packages/reown_walletkit/example/lib/widgets/wc_connection_request/network_section.dart
@@ -21,16 +21,43 @@ class NetworkSection extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     final colors = context.colors;
+    final isSingleChain = chains.length == 1;
+
+    final headerLabelStyle = TextStyle(
+      color: colors.textTertiary,
+      fontSize: 16.0,
+      fontWeight: FontWeight.w400,
+      letterSpacing: -0.16,
+      height: 18.0 / 16.0,
+    );
+
+    if (isSingleChain) {
+      return Container(
+        decoration: BoxDecoration(
+          color: colors.backgroundSecondary,
+          borderRadius: BorderRadius.circular(AppRadius.md),
+        ),
+        padding: const EdgeInsets.symmetric(
+          horizontal: AppSpacing.s4,
+          vertical: 14.0,
+        ),
+        child: Row(
+          children: [
+            Expanded(
+              child: Text('Network', style: headerLabelStyle),
+            ),
+            ChainIcon(
+              logoUrl: chains.first.logo,
+              size: 24.0,
+              showBorder: false,
+            ),
+          ],
+        ),
+      );
+    }
 
     return ExpandableSection(
-      headerLeft: Text(
-        'Network',
-        style: TextStyle(
-          color: colors.textTertiary,
-          fontSize: 14.0,
-          fontWeight: FontWeight.w500,
-        ),
-      ),
+      headerLeft: Text('Network', style: headerLabelStyle),
       headerRight: ChainIcons(
         logoUrls: chains
             .where((c) => selectedChainIds.contains(c.chainId))

--- a/packages/reown_walletkit/example/lib/widgets/wc_connection_request/verify_section.dart
+++ b/packages/reown_walletkit/example/lib/widgets/wc_connection_request/verify_section.dart
@@ -33,8 +33,10 @@ class VerifySection extends StatelessWidget {
         _cleanUrl(origin),
         style: TextStyle(
           color: colors.textTertiary,
-          fontSize: 14.0,
-          fontWeight: FontWeight.w500,
+          fontSize: 16.0,
+          fontWeight: FontWeight.w400,
+          letterSpacing: -0.16,
+          height: 18.0 / 16.0,
         ),
         overflow: TextOverflow.ellipsis,
       ),

--- a/packages/reown_walletkit/example/lib/widgets/wc_connection_request/wc_connect_modal.dart
+++ b/packages/reown_walletkit/example/lib/widgets/wc_connection_request/wc_connect_modal.dart
@@ -4,6 +4,7 @@ import 'package:reown_walletkit_wallet/dependencies/bottom_sheet/i_bottom_sheet_
 import 'package:reown_walletkit_wallet/models/chain_data.dart';
 import 'package:reown_walletkit_wallet/models/chain_metadata.dart';
 import 'package:reown_walletkit_wallet/theme/app_colors.dart';
+import 'package:reown_walletkit_wallet/theme/app_typography.dart';
 import 'package:reown_walletkit_wallet/theme/app_spacing.dart';
 import 'package:reown_walletkit_wallet/widgets/custom_button.dart';
 import 'package:reown_walletkit_wallet/widgets/shared/app_icon_widget.dart';
@@ -178,11 +179,7 @@ class _WCConnectModalState extends State<WCConnectModal> {
         // Title
         Text(
           'Connect your wallet to ${metadata.name}',
-          style: TextStyle(
-            color: colors.textPrimary,
-            fontSize: 18.0,
-            fontWeight: FontWeight.w600,
-          ),
+          style: context.textStyles.heading6,
           textAlign: TextAlign.center,
         ),
         const SizedBox(height: AppSpacing.s5),

--- a/packages/reown_walletkit/example/lib/widgets/wc_request_modal/wc_request_modal.dart
+++ b/packages/reown_walletkit/example/lib/widgets/wc_request_modal/wc_request_modal.dart
@@ -3,6 +3,7 @@ import 'package:reown_walletkit/reown_walletkit.dart';
 import 'package:reown_walletkit_wallet/dependencies/bottom_sheet/i_bottom_sheet_service.dart';
 import 'package:reown_walletkit_wallet/models/chain_metadata.dart';
 import 'package:reown_walletkit_wallet/theme/app_colors.dart';
+import 'package:reown_walletkit_wallet/theme/app_typography.dart';
 import 'package:reown_walletkit_wallet/theme/app_radius.dart';
 import 'package:reown_walletkit_wallet/theme/app_spacing.dart';
 import 'package:reown_walletkit_wallet/widgets/custom_button.dart';
@@ -85,12 +86,7 @@ class WCRequestModal extends StatelessWidget {
         // Title
         Text(
           title,
-          style: TextStyle(
-            color: colors.textPrimary,
-            fontSize: 20.0,
-            fontWeight: FontWeight.w400,
-            letterSpacing: -0.6,
-          ),
+          style: context.textStyles.heading6,
           textAlign: TextAlign.center,
         ),
         const SizedBox(height: AppSpacing.s5),

--- a/packages/reown_walletkit/example/lib/widgets/wc_request_modal/wc_request_modal.dart
+++ b/packages/reown_walletkit/example/lib/widgets/wc_request_modal/wc_request_modal.dart
@@ -8,6 +8,7 @@ import 'package:reown_walletkit_wallet/theme/app_spacing.dart';
 import 'package:reown_walletkit_wallet/widgets/custom_button.dart';
 import 'package:reown_walletkit_wallet/widgets/shared/app_icon_widget.dart';
 import 'package:reown_walletkit_wallet/widgets/shared/chain_icon_widget.dart';
+import 'package:reown_walletkit_wallet/widgets/shared/request_info_row.dart';
 import 'package:reown_walletkit_wallet/widgets/wc_connection_request/verify_section.dart';
 
 /// A single labeled content row shown inside [WCRequestModal].
@@ -115,7 +116,10 @@ class WCRequestModal extends StatelessWidget {
                 ...items.map(
                   (item) => Padding(
                     padding: const EdgeInsets.only(bottom: AppSpacing.s2),
-                    child: _InfoRow(item: item),
+                    child: RequestInfoRow(
+                      label: item.label,
+                      value: item.value,
+                    ),
                   ),
                 ),
               ],
@@ -256,52 +260,6 @@ class _NetworkRow extends StatelessWidget {
             ),
           Text(
             chain.name,
-            style: TextStyle(
-              color: colors.textPrimary,
-              fontSize: 16.0,
-              fontWeight: FontWeight.w400,
-              letterSpacing: -0.16,
-              height: 18.0 / 16.0,
-            ),
-          ),
-        ],
-      ),
-    );
-  }
-}
-
-class _InfoRow extends StatelessWidget {
-  const _InfoRow({required this.item});
-
-  final WCRequestItem item;
-
-  @override
-  Widget build(BuildContext context) {
-    final colors = context.colors;
-
-    return Container(
-      width: double.infinity,
-      decoration: BoxDecoration(
-        color: colors.foregroundPrimary,
-        borderRadius: BorderRadius.circular(AppRadius.md),
-      ),
-      padding: const EdgeInsets.all(AppSpacing.s5),
-      child: Column(
-        crossAxisAlignment: CrossAxisAlignment.start,
-        children: [
-          Text(
-            item.label,
-            style: TextStyle(
-              color: colors.textTertiary,
-              fontSize: 16.0,
-              fontWeight: FontWeight.w400,
-              letterSpacing: -0.16,
-              height: 18.0 / 16.0,
-            ),
-          ),
-          const SizedBox(height: AppSpacing.s2),
-          Text(
-            item.value,
             style: TextStyle(
               color: colors.textPrimary,
               fontSize: 16.0,

--- a/packages/reown_walletkit/example/lib/widgets/wc_request_modal/wc_request_modal.dart
+++ b/packages/reown_walletkit/example/lib/widgets/wc_request_modal/wc_request_modal.dart
@@ -1,0 +1,317 @@
+import 'package:flutter/material.dart';
+import 'package:reown_walletkit/reown_walletkit.dart';
+import 'package:reown_walletkit_wallet/dependencies/bottom_sheet/i_bottom_sheet_service.dart';
+import 'package:reown_walletkit_wallet/models/chain_metadata.dart';
+import 'package:reown_walletkit_wallet/theme/app_colors.dart';
+import 'package:reown_walletkit_wallet/theme/app_radius.dart';
+import 'package:reown_walletkit_wallet/theme/app_spacing.dart';
+import 'package:reown_walletkit_wallet/widgets/custom_button.dart';
+import 'package:reown_walletkit_wallet/widgets/shared/app_icon_widget.dart';
+import 'package:reown_walletkit_wallet/widgets/shared/chain_icon_widget.dart';
+import 'package:reown_walletkit_wallet/widgets/wc_connection_request/verify_section.dart';
+
+/// A single labeled content row shown inside [WCRequestModal].
+class WCRequestItem {
+  const WCRequestItem({required this.label, required this.value});
+
+  final String label;
+  final String value;
+}
+
+/// Compact key/value row rendered in the summary area.
+class WCRequestSummaryRow {
+  const WCRequestSummaryRow({required this.label, required this.value});
+
+  final String label;
+  final String value;
+}
+
+/// Redesigned request modal for sign/send/approve wallet requests.
+///
+/// Follows the same design language as [WCConnectModal]:
+///   - App icon + title
+///   - Expandable domain (verify) row
+///   - Read-only network row (when chain is provided)
+///   - Labeled content rows
+///   - Cancel + action buttons
+class WCRequestModal extends StatelessWidget {
+  const WCRequestModal({
+    super.key,
+    this.requester,
+    this.verifyContext,
+    this.chain,
+    required this.title,
+    required this.items,
+    this.summaryRows = const [],
+    this.approveLabel = 'Sign',
+    this.rejectLabel = 'Cancel',
+  });
+
+  final ConnectionMetadata? requester;
+  final VerifyContext? verifyContext;
+  final ChainMetadata? chain;
+  final String title;
+  final List<WCRequestItem> items;
+  final List<WCRequestSummaryRow> summaryRows;
+  final String approveLabel;
+  final String rejectLabel;
+
+  void _onReject(BuildContext context) {
+    if (Navigator.canPop(context)) {
+      Navigator.of(context).pop(WCBottomSheetResult.reject);
+    }
+  }
+
+  void _onApprove(BuildContext context) {
+    if (Navigator.canPop(context)) {
+      Navigator.of(context).pop(WCBottomSheetResult.one);
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final colors = context.colors;
+    final metadata = requester?.metadata;
+
+    return Column(
+      mainAxisSize: MainAxisSize.min,
+      children: [
+        const SizedBox(height: AppSpacing.s2),
+        // App icon
+        if (metadata != null)
+          Center(child: AppIcon(metadata: metadata, size: 64.0)),
+        const SizedBox(height: AppSpacing.s3),
+        // Title
+        Text(
+          title,
+          style: TextStyle(
+            color: colors.textPrimary,
+            fontSize: 20.0,
+            fontWeight: FontWeight.w400,
+            letterSpacing: -0.6,
+          ),
+          textAlign: TextAlign.center,
+        ),
+        const SizedBox(height: AppSpacing.s5),
+        // Scrollable content area
+        Flexible(
+          child: SingleChildScrollView(
+            child: Column(
+              mainAxisSize: MainAxisSize.min,
+              children: [
+                VerifySection(verifyContext: verifyContext),
+                if (verifyContext != null)
+                  const SizedBox(height: AppSpacing.s2),
+                if (chain != null) ...[
+                  _NetworkRow(chain: chain!),
+                  const SizedBox(height: AppSpacing.s2),
+                ],
+                ...summaryRows.map(
+                  (row) => Padding(
+                    padding: const EdgeInsets.only(bottom: AppSpacing.s2),
+                    child: _SummaryRow(row: row),
+                  ),
+                ),
+                ...items.map(
+                  (item) => Padding(
+                    padding: const EdgeInsets.only(bottom: AppSpacing.s2),
+                    child: _InfoRow(item: item),
+                  ),
+                ),
+              ],
+            ),
+          ),
+        ),
+        const SizedBox(height: AppSpacing.s5),
+        // Action buttons
+        Row(
+          children: [
+            CustomButton(
+              onTap: () => _onReject(context),
+              style: CustomButtonStyle.outlined,
+              child: Text(
+                rejectLabel,
+                style: TextStyle(
+                  color: colors.textPrimary,
+                  fontSize: 16.0,
+                  fontWeight: FontWeight.w400,
+                ),
+                textAlign: TextAlign.center,
+              ),
+            ),
+            const SizedBox(width: AppSpacing.s3),
+            CustomButton(
+              onTap: () => _onApprove(context),
+              type: CustomButtonType.normal,
+              child: Text(
+                approveLabel,
+                style: TextStyle(
+                  color: colors.onAccent,
+                  fontSize: 16.0,
+                  fontWeight: FontWeight.w400,
+                ),
+                textAlign: TextAlign.center,
+              ),
+            ),
+          ],
+        ),
+      ],
+    );
+  }
+}
+
+class _SummaryRow extends StatelessWidget {
+  const _SummaryRow({required this.row});
+
+  final WCRequestSummaryRow row;
+
+  @override
+  Widget build(BuildContext context) {
+    final colors = context.colors;
+
+    return Container(
+      width: double.infinity,
+      decoration: BoxDecoration(
+        color: colors.foregroundPrimary,
+        borderRadius: BorderRadius.circular(AppRadius.md),
+      ),
+      padding: const EdgeInsets.symmetric(
+        horizontal: AppSpacing.s5,
+        vertical: AppSpacing.s5,
+      ),
+      child: Row(
+        children: [
+          Text(
+            row.label,
+            style: TextStyle(
+              color: colors.textTertiary,
+              fontSize: 16.0,
+              fontWeight: FontWeight.w400,
+              letterSpacing: -0.16,
+              height: 18.0 / 16.0,
+            ),
+          ),
+          const SizedBox(width: AppSpacing.s2),
+          Expanded(
+            child: Text(
+              row.value,
+              style: TextStyle(
+                color: colors.textPrimary,
+                fontSize: 16.0,
+                fontWeight: FontWeight.w400,
+                letterSpacing: -0.16,
+                height: 18.0 / 16.0,
+              ),
+              textAlign: TextAlign.right,
+              overflow: TextOverflow.ellipsis,
+              maxLines: 1,
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+class _NetworkRow extends StatelessWidget {
+  const _NetworkRow({required this.chain});
+
+  final ChainMetadata chain;
+
+  @override
+  Widget build(BuildContext context) {
+    final colors = context.colors;
+
+    return Container(
+      width: double.infinity,
+      decoration: BoxDecoration(
+        color: colors.foregroundPrimary,
+        borderRadius: BorderRadius.circular(AppRadius.md),
+      ),
+      padding: const EdgeInsets.symmetric(
+        horizontal: AppSpacing.s5,
+        vertical: AppSpacing.s5,
+      ),
+      child: Row(
+        children: [
+          Text(
+            'Network',
+            style: TextStyle(
+              color: colors.textTertiary,
+              fontSize: 16.0,
+              fontWeight: FontWeight.w400,
+              letterSpacing: -0.16,
+              height: 18.0 / 16.0,
+            ),
+          ),
+          const Spacer(),
+          if (chain.logo.isNotEmpty)
+            Padding(
+              padding: const EdgeInsets.only(right: AppSpacing.s2),
+              child: ChainIcon(
+                logoUrl: chain.logo,
+                size: 24.0,
+                showBorder: false,
+              ),
+            ),
+          Text(
+            chain.name,
+            style: TextStyle(
+              color: colors.textPrimary,
+              fontSize: 16.0,
+              fontWeight: FontWeight.w400,
+              letterSpacing: -0.16,
+              height: 18.0 / 16.0,
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+class _InfoRow extends StatelessWidget {
+  const _InfoRow({required this.item});
+
+  final WCRequestItem item;
+
+  @override
+  Widget build(BuildContext context) {
+    final colors = context.colors;
+
+    return Container(
+      width: double.infinity,
+      decoration: BoxDecoration(
+        color: colors.foregroundPrimary,
+        borderRadius: BorderRadius.circular(AppRadius.md),
+      ),
+      padding: const EdgeInsets.all(AppSpacing.s5),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Text(
+            item.label,
+            style: TextStyle(
+              color: colors.textTertiary,
+              fontSize: 16.0,
+              fontWeight: FontWeight.w400,
+              letterSpacing: -0.16,
+              height: 18.0 / 16.0,
+            ),
+          ),
+          const SizedBox(height: AppSpacing.s2),
+          Text(
+            item.value,
+            style: TextStyle(
+              color: colors.textPrimary,
+              fontSize: 16.0,
+              fontWeight: FontWeight.w400,
+              letterSpacing: -0.16,
+              height: 18.0 / 16.0,
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}


### PR DESCRIPTION
# Description

Redesigns WalletKit example request approvals by introducing a new `WCRequestModal` and refreshing Kadena request UI to match.
Propagates requester metadata across chain services so approval modals show the calling app context consistently.
Improves approval safety with fallback summary rows (method/account/chain), method-aware approve labels, and an explicit EVM gas row.
Switches post-request success/error feedback to toastification and includes related WalletKit example visual refinements.

Resolves # (issue)

## How Has This Been Tested?

- `cd packages/reown_walletkit/example && flutter analyze $(git -C ../../.. diff --name-only -- 'packages/reown_walletkit/example/lib/**/*.dart' | sed 's#^packages/reown_walletkit/example/##')`

## Due Dilligence

* [ ] Breaking change
* [ ] Requires a documentation update
