### PR TITLE
feat(walletkit): add letter spacing to typography

### DIFF
--- a/packages/reown_walletkit/example/lib/theme/app_typography.dart
+++ b/packages/reown_walletkit/example/lib/theme/app_typography.dart
@@ -11,12 +11,14 @@ class AppTypography {
         color: _c.textSecondary,
         fontSize: 40.0,
         fontWeight: FontWeight.w500,
+        letterSpacing: -0.8,
       );
 
   TextStyle get subtitleText => TextStyle(
         color: _c.textPrimary,
         fontSize: 24.0,
         fontWeight: FontWeight.w500,
+        letterSpacing: -0.24,
       );
 
   TextStyle get heading6 => TextStyle(
@@ -25,29 +27,34 @@ class AppTypography {
         fontSize: 20.0,
         fontStyle: FontStyle.normal,
         fontWeight: FontWeight.w400,
+        letterSpacing: -0.6,
       );
 
   TextStyle get buttonText => TextStyle(
         color: _c.onAccent,
         fontSize: 16.0,
         fontWeight: FontWeight.w500,
+        letterSpacing: -0.16,
       );
 
   TextStyle get bodyTextBold => TextStyle(
         color: _c.textSecondary,
         fontSize: 14.0,
         fontWeight: FontWeight.w500,
+        letterSpacing: -0.14,
       );
 
   TextStyle get bodyText => TextStyle(
         color: _c.textSecondary,
         fontSize: 14.0,
         fontWeight: FontWeight.w400,
+        letterSpacing: -0.14,
       );
 
   TextStyle get bodyLightGray => TextStyle(
         color: _c.textSecondary,
         fontSize: 14.0,
+        letterSpacing: -0.14,
       );
 
   /// Used for general primary-colored labels (e.g. session item names).
@@ -55,6 +62,7 @@ class AppTypography {
         color: _c.textPrimary,
         fontSize: 14.0,
         fontWeight: FontWeight.w500,
+        letterSpacing: -0.14,
       );
 
   /// Used for connection widget info titles. Currently identical to
@@ -63,24 +71,28 @@ class AppTypography {
         color: _c.textPrimary,
         fontSize: 14.0,
         fontWeight: FontWeight.w500,
+        letterSpacing: -0.14,
       );
 
   TextStyle get layerTextStyle4 => TextStyle(
         color: _c.accent,
         fontSize: 14.0,
         fontWeight: FontWeight.w500,
+        letterSpacing: -0.14,
       );
 
   TextStyle get wcpTextPrimary => TextStyle(
         color: _c.textPrimary,
         fontSize: 16.0,
         fontWeight: FontWeight.w400,
+        letterSpacing: -0.16,
       );
 
   TextStyle get wcpTextSecondary => TextStyle(
         color: _c.textSecondary,
         fontSize: 16.0,
         fontWeight: FontWeight.w400,
+        letterSpacing: -0.16,
       );
 }
 

--- a/packages/reown_walletkit/example/lib/walletconnect_pay/wcp_shared_widgets.dart
+++ b/packages/reown_walletkit/example/lib/walletconnect_pay/wcp_shared_widgets.dart
@@ -4,6 +4,7 @@ import 'package:flutter_svg/flutter_svg.dart';
 import 'package:reown_walletkit_wallet/theme/app_colors.dart';
 import 'package:reown_walletkit_wallet/theme/app_radius.dart';
 import 'package:reown_walletkit_wallet/theme/app_spacing.dart';
+import 'package:reown_walletkit_wallet/theme/app_typography.dart';
 import 'package:reown_walletkit_wallet/walletconnect_pay/wcp_utils.dart';
 import 'package:reown_walletkit/reown_walletkit.dart';
 
@@ -14,16 +15,10 @@ class WCModalTitle extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    final colors = context.colors;
     return Center(
       child: Text(
         text,
-        style: TextStyle(
-          color: colors.textPrimary,
-          fontSize: 20.0,
-          fontWeight: FontWeight.w400,
-          fontFamily: 'KH Teka',
-        ),
+        style: context.textStyles.heading6,
         textAlign: TextAlign.center,
       ),
     );
@@ -65,11 +60,8 @@ class WCPrimaryButton extends StatelessWidget {
             alignment: Alignment.center,
             child: Text(
               text,
-              style: TextStyle(
+              style: context.textStyles.wcpTextPrimary.copyWith(
                 color: colors.textInvert,
-                fontSize: 16.0,
-                fontWeight: FontWeight.w400,
-                fontFamily: 'KH Teka',
               ),
               textAlign: TextAlign.center,
             ),
@@ -184,15 +176,12 @@ class _WCPTextFieldState extends State<WCPTextField> {
         focusNode: widget.focusNode,
         onSubmitted: widget.onSubmitted,
         style: widget.textStyle ??
-            TextStyle(
+            context.textStyles.buttonText.copyWith(
               color: colors.textPrimary,
-              fontSize: 16.0,
-              fontWeight: FontWeight.w500,
             ),
         placeholder: widget.label,
-        placeholderStyle: TextStyle(
+        placeholderStyle: context.textStyles.wcpTextPrimary.copyWith(
           color: colors.textTertiary,
-          fontSize: 16.0,
         ),
         decoration: const BoxDecoration(),
         padding: EdgeInsets.zero,
@@ -211,7 +200,6 @@ class WCPPaymentDetails extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    final colors = context.colors;
     return Row(
       mainAxisAlignment: MainAxisAlignment.center,
       crossAxisAlignment: CrossAxisAlignment.center,
@@ -222,12 +210,7 @@ class WCPPaymentDetails extends StatelessWidget {
             maxLines: 1,
             overflow: TextOverflow.ellipsis,
             text: TextSpan(
-              style: TextStyle(
-                color: colors.textPrimary,
-                fontSize: 20.0,
-                fontFamily: 'KH Teka',
-                fontWeight: FontWeight.w400,
-              ),
+              style: context.textStyles.heading6,
               children: [
                 const TextSpan(text: 'Pay '),
                 TextSpan(text: formatPayAmount(paymentInfo.amount)),
@@ -291,6 +274,7 @@ class _DefaultLogo extends StatelessWidget {
         color: context.colors.onBackgroundInvert,
         fontSize: 32,
         fontWeight: FontWeight.bold,
+        letterSpacing: -0.32,
       ),
     );
   }

--- a/packages/reown_walletkit/example/lib/widgets/wc_connection_request/wc_connection_request_widget.dart
+++ b/packages/reown_walletkit/example/lib/widgets/wc_connection_request/wc_connection_request_widget.dart
@@ -43,11 +43,7 @@ class WCConnectionRequestWidget extends StatelessWidget {
           const SizedBox(height: AppSpacing.s2),
           Text(
             '${requester!.metadata.name} ${StringConstants.wouldLikeToConnect}',
-            style: context.textStyles.heading6.copyWith(
-              fontSize: 18.0,
-              fontWeight: FontWeight.bold,
-              letterSpacing: -0.18,
-            ),
+            style: context.textStyles.heading6,
             textAlign: TextAlign.center,
           ),
           const SizedBox(height: AppSpacing.s2),

--- a/packages/reown_walletkit/example/lib/widgets/wc_connection_request/wc_connection_request_widget.dart
+++ b/packages/reown_walletkit/example/lib/widgets/wc_connection_request/wc_connection_request_widget.dart
@@ -5,6 +5,7 @@ import 'package:reown_walletkit_wallet/dependencies/i_walletkit_service.dart';
 import 'package:reown_walletkit_wallet/dependencies/key_service/i_key_service.dart';
 import 'package:reown_walletkit_wallet/theme/app_colors.dart';
 import 'package:reown_walletkit_wallet/theme/app_spacing.dart';
+import 'package:reown_walletkit_wallet/theme/app_typography.dart';
 import 'package:reown_walletkit_wallet/utils/namespace_model_builder.dart';
 import 'package:reown_walletkit_wallet/utils/string_constants.dart';
 import 'package:reown_walletkit_wallet/widgets/wc_connection_widget/wc_connection_widget.dart';
@@ -42,7 +43,11 @@ class WCConnectionRequestWidget extends StatelessWidget {
           const SizedBox(height: AppSpacing.s2),
           Text(
             '${requester!.metadata.name} ${StringConstants.wouldLikeToConnect}',
-            style: TextStyle(fontSize: 18.0, fontWeight: FontWeight.bold),
+            style: context.textStyles.heading6.copyWith(
+              fontSize: 18.0,
+              fontWeight: FontWeight.bold,
+              letterSpacing: -0.18,
+            ),
             textAlign: TextAlign.center,
           ),
           const SizedBox(height: AppSpacing.s2),
@@ -153,7 +158,10 @@ class VerifyHeader extends StatelessWidget {
         Expanded(
           child: Text(
             title,
-            style: TextStyle(color: iconColor, fontWeight: FontWeight.bold),
+            style: context.textStyles.bodyTextBold.copyWith(
+              color: iconColor,
+              fontWeight: FontWeight.bold,
+            ),
           ),
         ),
       ],
@@ -176,7 +184,12 @@ class VerifyBanner extends StatelessWidget {
   Widget build(BuildContext context) {
     return Column(
       children: [
-        Text(origin, style: const TextStyle(fontWeight: FontWeight.bold)),
+        Text(
+          origin,
+          style: context.textStyles.bodyTextBold.copyWith(
+            fontWeight: FontWeight.bold,
+          ),
+        ),
         const SizedBox.square(dimension: 8.0),
         Container(
           padding: const EdgeInsets.all(AppSpacing.s2),
@@ -191,7 +204,10 @@ class VerifyBanner extends StatelessWidget {
               Text(
                 text,
                 textAlign: TextAlign.center,
-                style: TextStyle(color: color, fontWeight: FontWeight.bold),
+                style: context.textStyles.bodyTextBold.copyWith(
+                  color: color,
+                  fontWeight: FontWeight.bold,
+                ),
               ),
             ],
           ),


### PR DESCRIPTION
# Description

Adds negative letter spacing to all AppTypography text styles for improved visual hierarchy and legibility. Consolidates previously duplicated inline TextStyle definitions in wcp_shared_widgets.dart and wc_connection_request_widget.dart to use centralized AppTypography styles via context.textStyles, improving maintainability and ensuring consistent application of the new letter spacing across the entire app.

## How Has This Been Tested?

Visual inspection of the rendered typography in the WalletKit example app. The changes are purely UI-focused and do not affect any business logic or protocols.

## Due Dilligence

* [ ] Breaking change
* [ ] Requires a documentation update