### PR TITLE
Update info modal copy, alignment, and text color

### DIFF
--- a/packages/reown_walletkit/example/lib/walletconnect_pay/wcp_modals/wcp_why_we_need_info.dart
+++ b/packages/reown_walletkit/example/lib/walletconnect_pay/wcp_modals/wcp_why_we_need_info.dart
@@ -85,7 +85,7 @@ class WCPWhyWeNeedInfoBody extends StatelessWidget {
             fontWeight: FontWeight.w400,
             height: 1.0,
           ),
-          textAlign: TextAlign.left,
+          textAlign: TextAlign.start,
         ),
         const SizedBox(height: AppSpacing.s2),
         Text(
@@ -97,7 +97,7 @@ class WCPWhyWeNeedInfoBody extends StatelessWidget {
             fontWeight: FontWeight.w400,
             height: 1.125,
           ),
-          textAlign: TextAlign.left,
+          textAlign: TextAlign.start,
         ),
         const SizedBox(height: AppSpacing.s2),
         Text(
@@ -110,7 +110,7 @@ class WCPWhyWeNeedInfoBody extends StatelessWidget {
             fontWeight: FontWeight.w400,
             height: 1.125,
           ),
-          textAlign: TextAlign.left,
+          textAlign: TextAlign.start,
         ),
       ],
     );

--- a/packages/reown_walletkit/example/lib/walletconnect_pay/wcp_modals/wcp_why_we_need_info.dart
+++ b/packages/reown_walletkit/example/lib/walletconnect_pay/wcp_modals/wcp_why_we_need_info.dart
@@ -75,41 +75,42 @@ class WCPWhyWeNeedInfoBody extends StatelessWidget {
   Widget build(BuildContext context) {
     final colors = context.colors;
     return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
       children: [
         Text(
-          'Why we need your information?',
+          'Why do we collect personal details?',
           style: TextStyle(
             color: colors.textPrimary,
             fontSize: 20.0,
             fontWeight: FontWeight.w400,
             height: 1.0,
           ),
-          textAlign: TextAlign.center,
+          textAlign: TextAlign.left,
         ),
         const SizedBox(height: AppSpacing.s2),
         Text(
-          'For regulatory compliance, we collect basic information on your '
-          'first payment: full name, date of birth, and place of birth.',
+          'To meet compliance requirements, some basic information is '
+          'collected from WalletConnect Pay users.',
           style: TextStyle(
-            color: colors.textTertiary,
+            color: colors.textSecondary,
             fontSize: 16.0,
             fontWeight: FontWeight.w400,
             height: 1.125,
           ),
-          textAlign: TextAlign.center,
+          textAlign: TextAlign.left,
         ),
         const SizedBox(height: AppSpacing.s2),
         Text(
-          'This information is tied to your wallet address and this specific '
-          'network. If you use the same wallet on this network again, you '
-          "won't need to provide it again.",
+          'This is typically a one-time step\u2014if you use the same wallet '
+          'on this network again, you won\'t need to provide the info again, '
+          'unless your information changes.',
           style: TextStyle(
-            color: colors.textTertiary,
+            color: colors.textSecondary,
             fontSize: 16.0,
             fontWeight: FontWeight.w400,
             height: 1.125,
           ),
-          textAlign: TextAlign.center,
+          textAlign: TextAlign.left,
         ),
       ],
     );


### PR DESCRIPTION
# Description

Updates the "Why do we collect personal details?" bottom sheet in the WalletKit Pay example to match the Figma design. Changed text alignment from center to left, updated copy for clarity, and fixed description text color from textTertiary to textSecondary.

## Due Dilligence

* [ ] Breaking change
* [ ] Requires a documentation update