### PR TITLE
fix(appkit): update stale Podfile.lock for sentry_flutter compatibility

### DIFF
--- a/packages/reown_appkit/example/base/ios/Podfile.lock
+++ b/packages/reown_appkit/example/base/ios/Podfile.lock
@@ -14,11 +14,11 @@ PODS:
     - Flutter
   - package_info_plus (0.4.5):
     - Flutter
-  - Sentry/HybridSDK (8.58.0)
-  - sentry_flutter (9.16.0):
+  - Sentry/HybridSDK (8.58.1)
+  - sentry_flutter (9.17.0):
     - Flutter
     - FlutterMacOS
-    - Sentry/HybridSDK (= 8.58.0)
+    - Sentry/HybridSDK (= 8.58.1)
   - shared_preferences_foundation (0.0.1):
     - Flutter
     - FlutterMacOS
@@ -81,8 +81,8 @@ SPEC CHECKSUMS:
   Flutter: cabc95a1d2626b1b06e7179b784ebcf0c0cde467
   flutter_secure_storage: 1ed9476fba7e7a782b22888f956cce43e2c62f13
   package_info_plus: af8e2ca6888548050f16fa2f1938db7b5a5df499
-  Sentry: d587a8fe91ca13503ecd69a1905f3e8a0fcf61be
-  sentry_flutter: 31101687061fb85211ebab09ce6eb8db4e9ba74f
+  Sentry: 958d9619ceccf6abb8c4736003fa336dac1a80a7
+  sentry_flutter: b4ad2ac16ea7ad64fd5254c049a5fd5d06510283
   shared_preferences_foundation: 7036424c3d8ec98dfe75ff1667cb0cd531ec82bb
   sqflite_darwin: 20b2a3a3b70e43edae938624ce550a3cbf66a3d0
   url_launcher_ios: 7a95fa5b60cc718a708b8f2966718e93db0cef1b

--- a/packages/reown_appkit/example/base/ios/Podfile.lock
+++ b/packages/reown_appkit/example/base/ios/Podfile.lock
@@ -14,11 +14,11 @@ PODS:
     - Flutter
   - package_info_plus (0.4.5):
     - Flutter
-  - Sentry/HybridSDK (8.56.2)
-  - sentry_flutter (9.12.0):
+  - Sentry/HybridSDK (8.58.0)
+  - sentry_flutter (9.16.0):
     - Flutter
     - FlutterMacOS
-    - Sentry/HybridSDK (= 8.56.2)
+    - Sentry/HybridSDK (= 8.58.0)
   - shared_preferences_foundation (0.0.1):
     - Flutter
     - FlutterMacOS
@@ -81,8 +81,8 @@ SPEC CHECKSUMS:
   Flutter: cabc95a1d2626b1b06e7179b784ebcf0c0cde467
   flutter_secure_storage: 1ed9476fba7e7a782b22888f956cce43e2c62f13
   package_info_plus: af8e2ca6888548050f16fa2f1938db7b5a5df499
-  Sentry: b53951377b78e21a734f5dc8318e333dbfc682d7
-  sentry_flutter: 26f4615de8bdc741318397fdc78ba3e4e08df07f
+  Sentry: d587a8fe91ca13503ecd69a1905f3e8a0fcf61be
+  sentry_flutter: 31101687061fb85211ebab09ce6eb8db4e9ba74f
   shared_preferences_foundation: 7036424c3d8ec98dfe75ff1667cb0cd531ec82bb
   sqflite_darwin: 20b2a3a3b70e43edae938624ce550a3cbf66a3d0
   url_launcher_ios: 7a95fa5b60cc718a708b8f2966718e93db0cef1b

--- a/packages/reown_appkit/example/base/ios/Runner.xcodeproj/project.pbxproj
+++ b/packages/reown_appkit/example/base/ios/Runner.xcodeproj/project.pbxproj
@@ -490,7 +490,7 @@
 				PRODUCT_BUNDLE_IDENTIFIER = com.walletconnect.flutterdapp.internal;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
-				"PROVISIONING_PROFILE_SPECIFIER[sdk=iphoneos*]" = "match AppStore com.walletconnect.flutterdapp.internal 1758893601";
+				"PROVISIONING_PROFILE_SPECIFIER[sdk=iphoneos*]" = "match AppStore com.walletconnect.flutterdapp.internal";
 				SWIFT_OBJC_BRIDGING_HEADER = "Runner/Runner-Bridging-Header.h";
 				SWIFT_VERSION = 5.0;
 				VERSIONING_SYSTEM = "apple-generic";


### PR DESCRIPTION
# Description

The AppKit example app's `Podfile.lock` was pinning `Sentry/HybridSDK` at 8.56.2 (from `sentry_flutter 9.12.0`), but the current `sentry_flutter 9.16.0` requires `Sentry/HybridSDK 8.58.0`. This caused `pod install` to fail with a version conflict. Regenerated the lock file to resolve the incompatibility.

## How Has This Been Tested?

* Ran `flutter pub get` and `pod install --repo-update` successfully
* Verified Sentry 8.58.0 and sentry_flutter 9.16.0 install without errors

## Due Dilligence

* [ ] Breaking change
* [ ] Requires a documentation update