### PR TITLE
feat(walletkit): support USDT/Permit2 two-action pay flow in sample

### DIFF
--- a/packages/reown_walletkit/example/lib/dependencies/chain_services/evm_service.dart
+++ b/packages/reown_walletkit/example/lib/dependencies/chain_services/evm_service.dart
@@ -285,6 +285,113 @@ class EVMService {
     return signature;
   }
 
+  // --- WalletConnect Pay helpers (Permit2 two-action flow) ---
+  //
+  // These are used by the sample's Pay flow to submit an ERC-20 `approve`
+  // transaction to Permit2 without showing the generic dapp-request approval
+  // sheet — the user already consented by tapping "Pay".
+
+  static final BigInt _polygonPriorityFloorWei = BigInt.from(30000000000); // 30 gwei
+  static final BigInt _defaultPriorityFloorWei = BigInt.from(1500000000); // 1.5 gwei
+
+  Future<({EtherAmount maxFeePerGas, EtherAmount maxPriorityFeePerGas})>
+      _getPayFees() async {
+    EtherAmount priority;
+    try {
+      final hex = await ethClient.makeRPCCall<String>(
+        'eth_maxPriorityFeePerGas',
+      );
+      priority = EtherAmount.fromBigInt(
+        EtherUnit.wei,
+        BigInt.parse(hex.replaceFirst('0x', ''), radix: 16),
+      );
+    } catch (_) {
+      priority = EtherAmount.zero();
+    }
+
+    final floor = chainSupported.chainId == 'eip155:137'
+        ? _polygonPriorityFloorWei
+        : _defaultPriorityFloorWei;
+    if (priority.getInWei < floor) {
+      priority = EtherAmount.fromBigInt(EtherUnit.wei, floor);
+    }
+
+    final block = await ethClient.getBlockInformation();
+    final baseFee = block.baseFeePerGas;
+    final maxFee = baseFee != null
+        ? EtherAmount.fromBigInt(
+            EtherUnit.wei,
+            baseFee.getInWei * BigInt.two + priority.getInWei,
+          )
+        : await ethClient.getGasPrice();
+    return (maxFeePerGas: maxFee, maxPriorityFeePerGas: priority);
+  }
+
+  Future<BigInt> _estimatePayGas(Transaction tx) async {
+    final gas = await ethClient.estimateGas(
+      sender: tx.from,
+      to: tx.to,
+      value: tx.value,
+      data: tx.data,
+    );
+    return gas * BigInt.from(6) ~/ BigInt.from(5);
+  }
+
+  /// Estimates the wei cost of the given Pay approval transaction, so the
+  /// review UI can display a "one-time approval fee" line. Returns null on
+  /// failure — callers should hide the row rather than block Pay.
+  Future<BigInt?> estimatePayApprovalFee(Map<String, dynamic> txParams) async {
+    try {
+      final tx = txParams.toTransaction();
+      final fees = await _getPayFees();
+      final gasLimit = await _estimatePayGas(tx);
+      return gasLimit * fees.maxFeePerGas.getInWei;
+    } catch (e) {
+      debugPrint('[SampleWallet] estimatePayApprovalFee failed: $e');
+      return null;
+    }
+  }
+
+  /// Sends the given Pay approval transaction and waits for the receipt.
+  /// Returns the transaction hash on success. Throws [PayApprovalFailed] when
+  /// the receipt reports a failed status, or [PayApprovalTimeout] when no
+  /// receipt is seen within 120s.
+  Future<String> sendPayTransaction(Map<String, dynamic> txParams) async {
+    final base = txParams.toTransaction();
+    final fees = await _getPayFees();
+    final gasLimit = await _estimatePayGas(base);
+    final tx = base.copyWith(
+      maxFeePerGas: fees.maxFeePerGas,
+      maxPriorityFeePerGas: fees.maxPriorityFeePerGas,
+      maxGas: gasLimit.toInt(),
+    );
+
+    final chainIdInt = int.parse(chainSupported.chainId.split(':').last);
+    final hash = await ethClient.sendTransaction(
+      _credentials,
+      tx,
+      chainId: chainIdInt,
+    );
+
+    const interval = Duration(seconds: 2);
+    const timeout = Duration(seconds: 120);
+    final deadline = DateTime.now().add(timeout);
+    while (DateTime.now().isBefore(deadline)) {
+      await Future.delayed(interval);
+      try {
+        final receipt = await ethClient.getTransactionReceipt(hash);
+        if (receipt == null) continue;
+        if (receipt.status == true) return hash;
+        throw PayApprovalFailed(hash);
+      } on PayApprovalFailed {
+        rethrow;
+      } catch (e) {
+        debugPrint('[SampleWallet] sendPayTransaction poll error: $e');
+      }
+    }
+    throw PayApprovalTimeout(hash);
+  }
+
   Future<void> ethSignTypedDataV4Handler(
     String topic,
     dynamic parameters,
@@ -799,4 +906,19 @@ class EVMService {
     updatedNamespaces[namespace] = newNamespaces;
     return updatedNamespaces;
   }
+}
+
+class PayApprovalFailed implements Exception {
+  PayApprovalFailed(this.hash);
+  final String hash;
+  @override
+  String toString() => 'Approval transaction failed ($hash)';
+}
+
+class PayApprovalTimeout implements Exception {
+  PayApprovalTimeout(this.hash);
+  final String hash;
+  @override
+  String toString() =>
+      'Approval transaction timed out waiting for confirmation ($hash)';
 }

--- a/packages/reown_walletkit/example/lib/dependencies/walletkit_service.dart
+++ b/packages/reown_walletkit/example/lib/dependencies/walletkit_service.dart
@@ -886,15 +886,23 @@ class WalletKitService implements IWalletKitService {
       return;
     }
 
-    if (result is! ConfirmPaymentRequest) {
+    if (result is! (ConfirmPaymentRequest, List<Action>)) {
       _pendingPaymentRequest = null;
       _currentPaymentOptions = null;
       throw result;
     }
 
+    final (signedRequest, resolvedActions) = result;
+    final selectedOption = response.options.firstWhere(
+      (o) => o.id == signedRequest.optionId,
+    );
     // Step 2: Confirming Payment
     final paymentStatusResult = await _bottomSheetHandler.queueBottomSheet(
-      widget: WCPConfirmingPayment(paymentRequest: result),
+      widget: WCPConfirmingPayment(
+        paymentRequest: signedRequest,
+        actions: resolvedActions,
+        tokenSymbol: selectedOption.amount.display.assetSymbol,
+      ),
     );
     if (paymentStatusResult is! PaymentStatus) {
       // confirmPayment threw an error — detect the error type and show result

--- a/packages/reown_walletkit/example/lib/walletconnect_pay/wcp_modals/wcp_confirming_payment.dart
+++ b/packages/reown_walletkit/example/lib/walletconnect_pay/wcp_modals/wcp_confirming_payment.dart
@@ -1,38 +1,125 @@
-import 'package:flutter/material.dart';
+import 'dart:convert';
+
+import 'package:flutter/material.dart' hide Action;
 import 'package:get_it/get_it.dart';
 import 'package:reown_walletkit/reown_walletkit.dart';
+import 'package:reown_walletkit_wallet/dependencies/chain_services/evm_service.dart';
 import 'package:reown_walletkit_wallet/dependencies/i_walletkit_service.dart';
 import 'package:reown_walletkit_wallet/theme/app_radius.dart';
 import 'package:reown_walletkit_wallet/theme/app_spacing.dart';
 import 'package:reown_walletkit_wallet/walletconnect_pay/wcp_shared_widgets.dart';
 
 class WCPConfirmingPayment extends StatefulWidget {
-  const WCPConfirmingPayment({super.key, required this.paymentRequest});
+  const WCPConfirmingPayment({
+    super.key,
+    required this.paymentRequest,
+    required this.actions,
+    required this.tokenSymbol,
+  });
 
   final ConfirmPaymentRequest paymentRequest;
+  final List<Action> actions;
+  final String tokenSymbol;
 
   @override
   State<WCPConfirmingPayment> createState() => _WCPConfirmingPaymentState();
 }
 
 class _WCPConfirmingPaymentState extends State<WCPConfirmingPayment> {
+  static const _processingLabel = 'Processing your payment...';
+  static const _finalizingLabel = 'Finalizing your payment...';
+
   final _walletKitService = GetIt.I<IWalletKitService>();
-  late final ConfirmPaymentRequest _paymentRequest;
+  late final bool _isMultiStep = widget.actions.length > 1;
+  late final _stepLabel = ValueNotifier<String>(_processingLabel);
+
+  String get _settingUpLabel =>
+      'Setting up ${widget.tokenSymbol} for the first time...';
 
   @override
   void initState() {
     super.initState();
-    _paymentRequest = widget.paymentRequest;
-    WidgetsBinding.instance.addPostFrameCallback((_) async {
-      try {
-        final response = await _walletKitService.confirmPayment(
-          _paymentRequest,
-        );
-        Navigator.of(context).pop(response.status);
-      } catch (e) {
-        Navigator.of(context).pop(e);
+    WidgetsBinding.instance.addPostFrameCallback((_) => _run());
+  }
+
+  @override
+  void dispose() {
+    _stepLabel.dispose();
+    super.dispose();
+  }
+
+  Future<void> _run() async {
+    try {
+      final signatures = <String>[];
+      for (final action in widget.actions) {
+        final method = action.walletRpc.method;
+        if (method == 'eth_sendTransaction') {
+          _stepLabel.value = _settingUpLabel;
+        } else {
+          _stepLabel.value =
+              _isMultiStep ? _finalizingLabel : _processingLabel;
+        }
+        signatures.add(await _executeAction(action));
       }
-    });
+      _stepLabel.value = _isMultiStep ? _finalizingLabel : _processingLabel;
+      final request = widget.paymentRequest.copyWith(signatures: signatures);
+      final response = await _walletKitService.confirmPayment(request);
+      if (!mounted) return;
+      Navigator.of(context).pop(response.status);
+    } catch (e) {
+      if (!mounted) return;
+      Navigator.of(context).pop(e);
+    }
+  }
+
+  Future<String> _executeAction(Action action) async {
+    final method = action.walletRpc.method;
+    final chainId = action.walletRpc.chainId;
+    final params = action.walletRpc.params;
+    final service = _walletKitService.getChainService<EVMService>(
+      chainId: chainId,
+    );
+
+    switch (method) {
+      case 'eth_signTypedData_v4':
+        final decoded = jsonDecode(params) as List<dynamic>;
+        final typedData = _ensureEip712Domain(decoded.last);
+        return service.ethSignTypedDataV4(typedData);
+      case 'eth_sendTransaction':
+        final decoded = jsonDecode(params) as List<dynamic>;
+        final txParams = Map<String, dynamic>.from(decoded.first as Map);
+        return service.sendPayTransaction(txParams);
+      default:
+        throw UnimplementedError('Unsupported pay method: $method');
+    }
+  }
+
+  // eth_sig_util_plus requires an EIP712Domain entry in `types`. The Permit2
+  // payload the backend returns omits it (JS libraries inject their own), so
+  // synthesize one from the fields actually present in `domain`.
+  String _ensureEip712Domain(dynamic typedData) {
+    final map = typedData is String
+        ? Map<String, dynamic>.from(jsonDecode(typedData) as Map)
+        : Map<String, dynamic>.from(typedData as Map);
+    final types = Map<String, dynamic>.from(
+      (map['types'] as Map?) ?? const <String, dynamic>{},
+    );
+    if (!types.containsKey('EIP712Domain')) {
+      final domain = (map['domain'] as Map?) ?? const <String, dynamic>{};
+      const candidates = <(String, String)>[
+        ('name', 'string'),
+        ('version', 'string'),
+        ('chainId', 'uint256'),
+        ('verifyingContract', 'address'),
+        ('salt', 'bytes32'),
+      ];
+      types['EIP712Domain'] = [
+        for (final (name, type) in candidates)
+          if (domain.containsKey(name)) {'name': name, 'type': type},
+      ];
+    }
+    map['types'] = types;
+    return jsonEncode(map);
   }
 
   @override
@@ -55,7 +142,22 @@ class _WCPConfirmingPaymentState extends State<WCPConfirmingPayment> {
             container: true,
             identifier: 'pay-loading-message',
             label: 'pay-loading-message',
-            child: WCModalTitle(text: 'Confirming your payment...'),
+            child: ValueListenableBuilder<String>(
+              valueListenable: _stepLabel,
+              builder: (context, label, _) {
+                return AnimatedSwitcher(
+                  duration: const Duration(milliseconds: 250),
+                  transitionBuilder: (child, animation) => FadeTransition(
+                    opacity: animation,
+                    child: child,
+                  ),
+                  child: WCModalTitle(
+                    key: ValueKey(label),
+                    text: label,
+                  ),
+                );
+              },
+            ),
           ),
           const SizedBox(height: AppSpacing.s6),
         ],

--- a/packages/reown_walletkit/example/lib/walletconnect_pay/wcp_modals/wcp_payment_details.dart
+++ b/packages/reown_walletkit/example/lib/walletconnect_pay/wcp_modals/wcp_payment_details.dart
@@ -15,6 +15,20 @@ import 'package:reown_walletkit_wallet/walletconnect_pay/wcp_modals/wcp_why_we_n
 import 'package:reown_walletkit_wallet/walletconnect_pay/wcp_shared_widgets.dart';
 import 'package:reown_walletkit_wallet/walletconnect_pay/wcp_utils.dart';
 
+/// Per-option payment preparation state: the resolved required actions and
+/// (when an approve tx is part of the flow) an estimated fee row.
+class _OptionState {
+  _OptionState({this.actions, this.approvalFeeWei, this.feeSymbol});
+
+  List<Action>? actions;
+  BigInt? approvalFeeWei;
+  String? feeSymbol;
+
+  bool get isReady => actions != null;
+  bool get hasApprovalAction =>
+      actions?.any((a) => a.walletRpc.method == 'eth_sendTransaction') ?? false;
+}
+
 class WCPPaymentDetailsWidget extends StatefulWidget {
   const WCPPaymentDetailsWidget({
     super.key,
@@ -37,10 +51,15 @@ class WCPPaymentDetailsWidget extends StatefulWidget {
 }
 
 class _WCPPaymentDetailsWidgetState extends State<WCPPaymentDetailsWidget> {
+  static const _payExpiry = Duration(seconds: 10);
+
   final _walletKitService = GetIt.I<IWalletKitService>();
   late final PaymentOptionsResponse paymentOptionsResponse;
   late ConfirmPaymentRequest confirmRequest;
   final Set<String> _collectDataCompletedIds = {};
+  final Map<String, _OptionState> _prep = {};
+  int _prepSeq = 0;
+
   bool _isProcessing = false;
   bool _isForward = true;
   bool _showReview = false;
@@ -52,6 +71,7 @@ class _WCPPaymentDetailsWidgetState extends State<WCPPaymentDetailsWidget> {
     confirmRequest = widget.paymentRequest;
     widget.showInfoPageNotifier?.addListener(_onInfoPageToggled);
     widget.showReviewNotifier?.addListener(_onReviewToggled);
+    _preloadFor(_selectedOption);
   }
 
   @override
@@ -81,6 +101,9 @@ class _WCPPaymentDetailsWidgetState extends State<WCPPaymentDetailsWidget> {
     );
   }
 
+  _OptionState get _selectedPrep =>
+      _prep.putIfAbsent(_selectedOption.id, _OptionState.new);
+
   bool _needsCollectData(PaymentOption option) {
     final url = option.collectData?.url;
     return url != null &&
@@ -88,42 +111,74 @@ class _WCPPaymentDetailsWidgetState extends State<WCPPaymentDetailsWidget> {
         !_collectDataCompletedIds.contains(option.id);
   }
 
-  String _sign(Action action) {
-    final method = action.walletRpc.method;
-    final chainId = action.walletRpc.chainId;
-    final params = action.walletRpc.params;
-    final service = _walletKitService.getChainService<EVMService>(
-      chainId: chainId,
+  /// Fetch the required actions for [option] (if not already present on the
+  /// option) and estimate the approval fee when present. Uses a monotonic
+  /// [_prepSeq] so that responses from a previously-selected option cannot
+  /// overwrite the current one.
+  Future<void> _preloadFor(PaymentOption option) async {
+    final state = _prep.putIfAbsent(option.id, _OptionState.new);
+    if (state.isReady) return;
+
+    final seq = ++_prepSeq;
+
+    List<Action> actions;
+    if (option.actions.isNotEmpty) {
+      actions = option.actions;
+    } else {
+      try {
+        actions = await _walletKitService.getRequiredPaymentActions(
+          option.id,
+          confirmRequest.paymentId,
+        );
+      } catch (e) {
+        debugPrint('[SampleWallet] preload actions failed for ${option.id}: $e');
+        return;
+      }
+    }
+    if (!mounted || seq != _prepSeq) return;
+    setState(() => state.actions = actions);
+
+    final approveTx = actions.firstWhere(
+      (a) => a.walletRpc.method == 'eth_sendTransaction',
+      orElse: () => actions.first,
     );
-    switch (method) {
-      case 'eth_signTypedData_v4':
-        final decodedParams = jsonDecode(params) as List<dynamic>;
-        final typedData = decodedParams.last;
-        return service.ethSignTypedDataV4(typedData);
-      case 'personal_sign':
-        throw UnimplementedError('personal_sign not yet implemented');
-      default:
-        throw UnimplementedError('Unsupported signing method: $method');
+    if (approveTx.walletRpc.method != 'eth_sendTransaction') return;
+
+    try {
+      final service = _walletKitService.getChainService<EVMService>(
+        chainId: approveTx.walletRpc.chainId,
+      );
+      final decoded =
+          (jsonDecode(approveTx.walletRpc.params) as List).first as Map;
+      final fee = await service.estimatePayApprovalFee(
+        Map<String, dynamic>.from(decoded),
+      );
+      if (!mounted || seq != _prepSeq) return;
+      setState(() {
+        state.approvalFeeWei = fee;
+        state.feeSymbol = service.chainSupported.currency;
+      });
+    } catch (e) {
+      debugPrint('[SampleWallet] estimatePayApprovalFee error: $e');
     }
   }
 
   Future<void> _signAndPay() async {
-    try {
-      final actions = List<Action>.from(_selectedOption.actions);
-      if (actions.isEmpty) {
-        final requiredActions =
-            await _walletKitService.getRequiredPaymentActions(
-          _selectedOption.id,
-          confirmRequest.paymentId,
-        );
-        actions.addAll(requiredActions);
+    final started = DateTime.now();
+    _OptionState state = _selectedPrep;
+    while (!state.isReady) {
+      if (DateTime.now().difference(started) > _payExpiry) {
+        if (!mounted) return;
+        Navigator.of(context).pop(PaymentStatus.expired);
+        return;
       }
-      final signatures = actions.map((action) => _sign(action)).toList();
-      confirmRequest = confirmRequest.copyWith(signatures: signatures);
-      Navigator.of(context).pop(confirmRequest);
-    } catch (e) {
-      Navigator.of(context).pop(e);
+      await Future.delayed(const Duration(milliseconds: 120));
+      if (!mounted) return;
+      state = _selectedPrep;
     }
+
+    if (!mounted) return;
+    Navigator.of(context).pop((confirmRequest, state.actions!));
   }
 
   Future<void> _handleConfirmOrNext() async {
@@ -171,6 +226,12 @@ class _WCPPaymentDetailsWidgetState extends State<WCPPaymentDetailsWidget> {
         ? 'Continue'
         : 'Pay ${formatPayAmount(paymentInfo.amount)}';
 
+    final prep = _selectedPrep;
+    final showApprovalRow = _showReview ||
+        !_hasMultipleOptions && !selectedNeedsCollectData;
+    final payEnabled =
+        !_isProcessing && (showContinue || prep.isReady);
+
     return Column(
       mainAxisSize: MainAxisSize.min,
       crossAxisAlignment: CrossAxisAlignment.start,
@@ -191,12 +252,17 @@ class _WCPPaymentDetailsWidgetState extends State<WCPPaymentDetailsWidget> {
               setState(() {
                 confirmRequest = confirmRequest.copyWith(optionId: option.id);
               });
+              _preloadFor(option);
             },
           ),
+        if (showApprovalRow && prep.hasApprovalAction) ...[
+          const SizedBox(height: AppSpacing.s3),
+          _ApprovalFeeRow(feeWei: prep.approvalFeeWei, symbol: prep.feeSymbol),
+        ],
         const SizedBox(height: AppSpacing.s5),
         WCPrimaryButton(
           onPressed: _handleConfirmOrNext,
-          enabled: !_isProcessing,
+          enabled: payEnabled,
           text: buttonText,
           testId: showContinue ? 'pay-button-continue' : 'pay-button-pay',
         ),
@@ -297,6 +363,70 @@ class _WCPPaymentDetailsWidgetState extends State<WCPPaymentDetailsWidget> {
       padding: EdgeInsets.zero,
       child: _buildDetailsView(context),
     );
+  }
+}
+
+class _ApprovalFeeRow extends StatelessWidget {
+  const _ApprovalFeeRow({required this.feeWei, required this.symbol});
+
+  final BigInt? feeWei;
+  final String? symbol;
+
+  @override
+  Widget build(BuildContext context) {
+    final colors = context.colors;
+    final String valueText;
+    if (feeWei == null || symbol == null) {
+      valueText = '…';
+    } else {
+      valueText = _format(feeWei!, symbol!);
+    }
+    return Semantics(
+      container: true,
+      identifier: 'pay-review-approval-fee',
+      label: 'pay-review-approval-fee',
+      child: Container(
+        decoration: BoxDecoration(
+          color: colors.foregroundPrimary,
+          borderRadius: BorderRadius.circular(16.0),
+        ),
+        height: 68.0,
+        padding: const EdgeInsets.symmetric(horizontal: AppSpacing.s5),
+        alignment: Alignment.center,
+        child: Row(
+          children: [
+            Text(
+              'One-time approval fee',
+              style: TextStyle(
+                color: colors.textTertiary,
+                fontSize: 16.0,
+                fontWeight: FontWeight.w400,
+                fontFamily: 'KH Teka',
+              ),
+            ),
+            const Spacer(),
+            Text(
+              valueText,
+              style: TextStyle(
+                color: colors.textPrimary,
+                fontSize: 16.0,
+                fontWeight: FontWeight.w400,
+                fontFamily: 'KH Teka',
+              ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+
+  static String _format(BigInt wei, String symbol) {
+    // 1 ether = 1e18 wei. Show four significant decimals.
+    final ether = wei / BigInt.from(10).pow(18);
+    if (ether == 0 && wei > BigInt.zero) {
+      return '< 0.0001 $symbol';
+    }
+    return '${ether.toStringAsFixed(4)} $symbol';
   }
 }
 

--- a/packages/reown_walletkit/example/lib/walletconnect_pay/wcp_modals/wcp_payment_details.dart
+++ b/packages/reown_walletkit/example/lib/walletconnect_pay/wcp_modals/wcp_payment_details.dart
@@ -138,6 +138,7 @@ class _WCPPaymentDetailsWidgetState extends State<WCPPaymentDetailsWidget> {
     if (!mounted || seq != _prepSeq) return;
     setState(() => state.actions = actions);
 
+    if (actions.isEmpty) return;
     final approveTx = actions.firstWhere(
       (a) => a.walletRpc.method == 'eth_sendTransaction',
       orElse: () => actions.first,
@@ -213,6 +214,7 @@ class _WCPPaymentDetailsWidgetState extends State<WCPPaymentDetailsWidget> {
       setState(() => _showReview = true);
       widget.showReviewNotifier?.value = true;
     } else {
+      setState(() => _isProcessing = true);
       await _signAndPay();
     }
   }
@@ -422,8 +424,8 @@ class _ApprovalFeeRow extends StatelessWidget {
 
   static String _format(BigInt wei, String symbol) {
     // 1 ether = 1e18 wei. Show four significant decimals.
-    final ether = wei / BigInt.from(10).pow(18);
-    if (ether == 0 && wei > BigInt.zero) {
+    final ether = wei.toDouble() / 1e18;
+    if (ether > 0 && ether < 0.0001) {
       return '< 0.0001 $symbol';
     }
     return '${ether.toStringAsFixed(4)} $symbol';


### PR DESCRIPTION
# Description

Adds support for WalletConnect Pay options that require a two-step Permit2 flow — an on-chain ERC-20 \`approve\` followed by an EIP-712 typed-data signature — to the WalletKit sample. Previously the wallet only handled single-step \`eth_signTypedData_v4\` options and threw \`UnimplementedError\` for any \`eth_sendTransaction\` action, blocking USDT and any other Permit2-gated ERC-20.

This mirrors the same support already shipped in [reown-com/react-native-examples#472](https://github.com/reown-com/react-native-examples/pull/472), [reown-kotlin#371](https://github.com/reown-com/reown-kotlin/pull/371), and [reown-swift#307](https://github.com/reown-com/reown-swift/pull/307). The change is generic — no USDT-specific code, no new Yttrium / model / native plugin changes.

Highlights:
- New \`EVMService.sendPayTransaction\` (EIP-1559 fees with 30 gwei Polygon priority floor, 20%-buffered gas, 120 s receipt poll) and \`estimatePayApprovalFee\` for the review row.
- The confirming modal now owns sequential action execution and animates between \"Setting up <TOKEN> for the first time...\", \"Finalizing your payment...\", and \"Processing your payment...\" — matching the Swift/Kotlin labels.
- Payment details preloads required actions per option with race-safe sequencing, renders a \"One-time approval fee\" row when an approve action is needed, and applies a 10 s expiry guard on Pay tap.
- \`eth_sig_util_plus\` requires \`EIP712Domain\` in \`types\` (unlike JS); when the Permit2 payload omits it, we synthesize the entry from the present \`domain\` fields.

Resolves # (issue)

## How Has This Been Tested?

Manually on iOS simulator with a funded test wallet on Polygon and a USDT payment link generated by the Pay merchant demo: scanned, saw the \"One-time approval fee\" line and matching POL amount, tapped Pay, observed the loader animate through \"Setting up USDT...\" → \"Finalizing your payment...\", and the success result modal at the end. Regression-checked the existing USDC single-step flow — no approval-fee row appears and the loader stays on \"Processing your payment...\". \`flutter analyze\` is clean.

## Due Dilligence

* [ ] Breaking change
* [ ] Requires a documentation update