### PR TITLE
wallet sample: cover pay action signature ordering

### DIFF
--- a/packages/reown_walletkit/example/lib/walletconnect_pay/wcp_modals/wcp_confirming_payment.dart
+++ b/packages/reown_walletkit/example/lib/walletconnect_pay/wcp_modals/wcp_confirming_payment.dart
@@ -9,10 +9,8 @@ import 'package:reown_walletkit_wallet/theme/app_radius.dart';
 import 'package:reown_walletkit_wallet/theme/app_spacing.dart';
 import 'package:reown_walletkit_wallet/walletconnect_pay/wcp_shared_widgets.dart';
 
-@visibleForTesting
 typedef WCPActionExecutor = Future<String> Function(Action action);
 
-@visibleForTesting
 Future<List<String>> collectWCPActionSignatures({
   required List<Action> actions,
   required WCPActionExecutor executeAction,

--- a/packages/reown_walletkit/example/lib/walletconnect_pay/wcp_modals/wcp_confirming_payment.dart
+++ b/packages/reown_walletkit/example/lib/walletconnect_pay/wcp_modals/wcp_confirming_payment.dart
@@ -9,6 +9,23 @@ import 'package:reown_walletkit_wallet/theme/app_radius.dart';
 import 'package:reown_walletkit_wallet/theme/app_spacing.dart';
 import 'package:reown_walletkit_wallet/walletconnect_pay/wcp_shared_widgets.dart';
 
+@visibleForTesting
+typedef WCPActionExecutor = Future<String> Function(Action action);
+
+@visibleForTesting
+Future<List<String>> collectWCPActionSignatures({
+  required List<Action> actions,
+  required WCPActionExecutor executeAction,
+  void Function(Action action)? onActionStarted,
+}) async {
+  final signatures = <String>[];
+  for (final action in actions) {
+    onActionStarted?.call(action);
+    signatures.add(await executeAction(action));
+  }
+  return signatures;
+}
+
 class WCPConfirmingPayment extends StatefulWidget {
   const WCPConfirmingPayment({
     super.key,
@@ -50,17 +67,11 @@ class _WCPConfirmingPaymentState extends State<WCPConfirmingPayment> {
 
   Future<void> _run() async {
     try {
-      final signatures = <String>[];
-      for (final action in widget.actions) {
-        final method = action.walletRpc.method;
-        if (method == 'eth_sendTransaction') {
-          _stepLabel.value = _settingUpLabel;
-        } else {
-          _stepLabel.value =
-              _isMultiStep ? _finalizingLabel : _processingLabel;
-        }
-        signatures.add(await _executeAction(action));
-      }
+      final signatures = await collectWCPActionSignatures(
+        actions: widget.actions,
+        executeAction: _executeAction,
+        onActionStarted: _updateStepLabel,
+      );
       _stepLabel.value = _isMultiStep ? _finalizingLabel : _processingLabel;
       final request = widget.paymentRequest.copyWith(signatures: signatures);
       final response = await _walletKitService.confirmPayment(request);
@@ -69,6 +80,15 @@ class _WCPConfirmingPaymentState extends State<WCPConfirmingPayment> {
     } catch (e) {
       if (!mounted) return;
       Navigator.of(context).pop(e);
+    }
+  }
+
+  void _updateStepLabel(Action action) {
+    final method = action.walletRpc.method;
+    if (method == 'eth_sendTransaction') {
+      _stepLabel.value = _settingUpLabel;
+    } else {
+      _stepLabel.value = _isMultiStep ? _finalizingLabel : _processingLabel;
     }
   }
 
@@ -147,14 +167,9 @@ class _WCPConfirmingPaymentState extends State<WCPConfirmingPayment> {
               builder: (context, label, _) {
                 return AnimatedSwitcher(
                   duration: const Duration(milliseconds: 250),
-                  transitionBuilder: (child, animation) => FadeTransition(
-                    opacity: animation,
-                    child: child,
-                  ),
-                  child: WCModalTitle(
-                    key: ValueKey(label),
-                    text: label,
-                  ),
+                  transitionBuilder: (child, animation) =>
+                      FadeTransition(opacity: animation, child: child),
+                  child: WCModalTitle(key: ValueKey(label), text: label),
                 );
               },
             ),

--- a/packages/reown_walletkit/example/test/wcp_confirming_payment_test.dart
+++ b/packages/reown_walletkit/example/test/wcp_confirming_payment_test.dart
@@ -45,4 +45,22 @@ void main() {
       expect(signatures, ['0xapprovaltxhash', '0xtypeddatasignature']);
     },
   );
+
+  test('collectWCPActionSignatures propagates executeAction errors', () async {
+    expect(
+      () => collectWCPActionSignatures(
+        actions: [
+          const Action(
+            walletRpc: WalletRpcAction(
+              chainId: 'eip155:8453',
+              method: 'eth_sendTransaction',
+              params: '[]',
+            ),
+          ),
+        ],
+        executeAction: (_) async => throw Exception('user rejected'),
+      ),
+      throwsA(isA<Exception>()),
+    );
+  });
 }

--- a/packages/reown_walletkit/example/test/wcp_confirming_payment_test.dart
+++ b/packages/reown_walletkit/example/test/wcp_confirming_payment_test.dart
@@ -1,0 +1,48 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:reown_walletkit/reown_walletkit.dart';
+import 'package:reown_walletkit_wallet/walletconnect_pay/wcp_modals/wcp_confirming_payment.dart';
+
+void main() {
+  test(
+    'collectWCPActionSignatures includes transaction hash in action order',
+    () async {
+      final actions = [
+        const Action(
+          walletRpc: WalletRpcAction(
+            chainId: 'eip155:8453',
+            method: 'eth_sendTransaction',
+            params: '[]',
+          ),
+        ),
+        const Action(
+          walletRpc: WalletRpcAction(
+            chainId: 'eip155:8453',
+            method: 'eth_signTypedData_v4',
+            params: '[]',
+          ),
+        ),
+      ];
+      final startedMethods = <String>[];
+
+      final signatures = await collectWCPActionSignatures(
+        actions: actions,
+        onActionStarted: (action) {
+          startedMethods.add(action.walletRpc.method);
+        },
+        executeAction: (action) async {
+          switch (action.walletRpc.method) {
+            case 'eth_sendTransaction':
+              return '0xapprovaltxhash';
+            case 'eth_signTypedData_v4':
+              return '0xtypeddatasignature';
+            default:
+              throw UnimplementedError(action.walletRpc.method);
+          }
+        },
+      );
+
+      expect(startedMethods, ['eth_sendTransaction', 'eth_signTypedData_v4']);
+      expect(signatures, ['0xapprovaltxhash', '0xtypeddatasignature']);
+    },
+  );
+}


### PR DESCRIPTION
# Description

Extract a `collectWCPActionSignatures` helper from `WCPConfirmingPayment` so the per-action label and signature collection flow can be unit tested without instantiating the widget, and add a test asserting that signatures are returned in action order and the step label callback fires for each action.

Resolves # (issue)

## How Has This Been Tested?

- `flutter test packages/reown_walletkit/example/test/wcp_confirming_payment_test.dart`

## Due Dilligence

* [ ] Breaking change
* [ ] Requires a documentation update