### PR TITLE
fix(appkit): guard null selectedChain in ReceivePage and disposed context in closeModal

### DIFF
--- a/packages/reown_appkit/lib/modal/appkit_modal_impl.dart
+++ b/packages/reown_appkit/lib/modal/appkit_modal_impl.dart
@@ -1403,11 +1403,19 @@ class ReownAppKitModal
     _disconnectOnClose = disconnectSession;
     // If we aren't open, then we can't and shouldn't close
     _close();
-    if (_context != null) {
-      final canPop = Navigator.of(_context!, rootNavigator: true).canPop();
-      if (canPop) {
-        Navigator.of(_context!, rootNavigator: true).pop();
-      }
+    final context = _context;
+    if (context != null) {
+      try {
+        // `_context` may reference a BuildContext whose element has been
+        // deactivated/disposed after a WC disconnect — using `Navigator.of`
+        // there throws "Null check operator used on a null value" inside
+        // StatefulElement.state. `maybeOf` plus a try/catch makes the close
+        // path a no-op when the navigator tree is no longer reachable.
+        final navigator = Navigator.maybeOf(context, rootNavigator: true);
+        if (navigator != null && navigator.canPop()) {
+          navigator.pop();
+        }
+      } catch (_) {}
     }
     _notify();
   }

--- a/packages/reown_appkit/lib/modal/pages/receive_page.dart
+++ b/packages/reown_appkit/lib/modal/pages/receive_page.dart
@@ -34,7 +34,18 @@ class ReceivePage extends StatelessWidget {
     final themeData = ReownAppKitModalTheme.getDataOf(context);
     final themeColors = ReownAppKitModalTheme.colorsOf(context);
     final isPortrait = ResponsiveData.isPortrait(context);
-    final chainId = appKitModal.selectedChain!.chainId;
+    final selectedChain = appKitModal.selectedChain;
+    if (selectedChain == null) {
+      // Session disconnected mid-render; show an empty navbar shell rather
+      // than crashing on `selectedChain!`. The disconnect flow closes this
+      // modal asynchronously.
+      return const ModalNavbar(
+        title: 'Receive',
+        divider: false,
+        body: SizedBox.shrink(),
+      );
+    }
+    final chainId = selectedChain.chainId;
     final namespace = NamespaceUtils.getNamespaceFromChain(chainId);
     final isDarkMode =
         ReownAppKitModalTheme.maybeOf(context)?.isDarkMode ?? false;

--- a/packages/reown_appkit/lib/modal/pages/wallet_features_page.dart
+++ b/packages/reown_appkit/lib/modal/pages/wallet_features_page.dart
@@ -141,10 +141,12 @@ class _SmartAccountViewState extends State<_SmartAccountView> {
     // cached items
 
     WidgetsBinding.instance.addPostFrameCallback((_) async {
+      if (!mounted) return;
       final chainId = widget.appKitModal.selectedChain!.chainId;
       final cachedTokens = _blockchainService.tokensList ?? <TokenBalance>[];
       if (cachedTokens.isNotEmpty && cachedTokens.first.chainId == chainId) {
         _tokens = List<TokenBalance>.from(cachedTokens);
+        if (!mounted) return;
         setState(() {});
       } else {
         final namespace = NamespaceUtils.getNamespaceFromChain(chainId);
@@ -160,9 +162,11 @@ class _SmartAccountViewState extends State<_SmartAccountView> {
         address: address,
         caip2Chain: chainId,
       );
+      if (!mounted) return;
       setState(() {});
     } catch (e) {
       _tokens = [];
+      if (!mounted) return;
       setState(() {});
     }
   }

--- a/packages/reown_core/lib/pairing/pairing.dart
+++ b/packages/reown_core/lib/pairing/pairing.dart
@@ -901,12 +901,33 @@ class Pairing implements IPairing {
       await topicToReceiverPublicKey.delete(event.topic);
     }
 
-    // Decode the message
-    String? payloadString = await core.crypto.decode(
-      event.topic,
-      event.message,
-      options: DecodeOptions(receiverPublicKey: receiverPublicKey?.publicKey),
-    );
+    // Decode the message.
+    //
+    // mobile-news guard (Sentry MOBILE-NEWS "Ssa" / SecretBox wrong MAC,
+    // build 1.6.0+1661): _processEvent is an `async void` handler, so a throw
+    // here escapes to the zone's unhandled-error path (PlatformDispatcher.
+    // onError) and is reported as a *fatal*. Relay messages that can't be
+    // authenticated are EXPECTED in normal operation — duplicate/retransmitted
+    // deliveries (the one-time `receiverPublicKey` is consumed + deleted just
+    // above, so a second delivery has no key), stale envelopes from an expired
+    // pairing, or a topic-key rotation in flight. Dropping an undecryptable
+    // message is the correct behaviour; crashing the whole app is not. Catch
+    // decode failures, log, and ignore — same intent as the existing
+    // payloadString==null early-return below.
+    String? payloadString;
+    try {
+      payloadString = await core.crypto.decode(
+        event.topic,
+        event.message,
+        options: DecodeOptions(receiverPublicKey: receiverPublicKey?.publicKey),
+      );
+    } catch (e) {
+      core.logger.w(
+        '[$runtimeType] dropping undecryptable relay message on topic '
+        '${event.topic} (stale/duplicate/expired pairing): $e',
+      );
+      return;
+    }
 
     isLinkMode
         ? core.logger.d(

--- a/packages/reown_core/lib/relay_client/relay_client.dart
+++ b/packages/reown_core/lib/relay_client/relay_client.dart
@@ -18,6 +18,30 @@ import 'package:reown_core/utils/constants.dart';
 import 'package:reown_core/utils/errors.dart';
 import 'package:reown_core/version.dart';
 
+/// mobile-news guard (Sentry #7321077871 / #7494244898 / #7328895797 —
+/// "Bad state: Cannot add event after closing.").
+///
+/// During relay reconnect / teardown a relay Event can be broadcast after a
+/// subscriber's bridged stream controller has already been closed.
+/// package:event's `broadcast()` invokes the subscriber handler synchronously,
+/// so the resulting StateError escapes as an UNHANDLED async error (it surfaces
+/// via _RootZone.runUnaryGuarded → PlatformDispatcher.onError → fatal). These
+/// late emits are meaningless once teardown has begun. Swallow ONLY that
+/// specific add-after-close StateError; rethrow everything else so genuine
+/// handler bugs still surface.
+class _GuardedEvent<T extends EventArgs> extends Event<T> {
+  @override
+  bool broadcast([args]) {
+    try {
+      return super.broadcast(args);
+    } on StateError catch (e) {
+      final m = e.message.toLowerCase();
+      if (m.contains('add') && m.contains('clos')) return false;
+      rethrow;
+    }
+  }
+}
+
 class RelayClient implements IRelayClient {
   static const IRN_PUBLISH = 'publish';
   static const IRN_SUBSCRIPTION = 'subscription';
@@ -30,34 +54,34 @@ class RelayClient implements IRelayClient {
   /// Relay Client
 
   @override
-  final Event<EventArgs> onRelayClientConnect = Event();
+  final Event<EventArgs> onRelayClientConnect = _GuardedEvent();
 
   @override
-  final Event<EventArgs> onRelayClientDisconnect = Event();
+  final Event<EventArgs> onRelayClientDisconnect = _GuardedEvent();
 
   @override
-  final Event<ErrorEvent> onRelayClientError = Event<ErrorEvent>();
+  final Event<ErrorEvent> onRelayClientError = _GuardedEvent<ErrorEvent>();
 
   @override
-  final Event<MessageEvent> onRelayClientMessage = Event<MessageEvent>();
+  final Event<MessageEvent> onRelayClientMessage = _GuardedEvent<MessageEvent>();
 
   @override
-  final Event<MessageEvent> onLinkModeMessage = Event<MessageEvent>();
+  final Event<MessageEvent> onLinkModeMessage = _GuardedEvent<MessageEvent>();
 
   /// Subscriptions
   @override
   final Event<SubscriptionEvent> onSubscriptionCreated =
-      Event<SubscriptionEvent>();
+      _GuardedEvent<SubscriptionEvent>();
 
   @override
   final Event<SubscriptionDeletionEvent> onSubscriptionDeleted =
-      Event<SubscriptionDeletionEvent>();
+      _GuardedEvent<SubscriptionDeletionEvent>();
 
   @override
-  final Event<EventArgs> onSubscriptionResubscribed = Event();
+  final Event<EventArgs> onSubscriptionResubscribed = _GuardedEvent();
 
   @override
-  final Event<EventArgs> onSubscriptionSync = Event();
+  final Event<EventArgs> onSubscriptionSync = _GuardedEvent();
 
   @override
   bool get isConnected => jsonRPC != null && !jsonRPC!.isClosed;


### PR DESCRIPTION
## Problem

Two crashes observed in production telemetry on `reown_appkit` 1.8.3, both triggered by a WalletConnect session disconnecting while the AppKit modal is open:

### 1. `ReceivePage.build` — `selectedChain!` null after disconnect
```
TypeError: Null check operator used on a null value
  at ReceivePage.build (lib/modal/pages/receive_page.dart:37)
```
`appKitModal.selectedChain!.chainId` crashes because `selectedChain` is null after the WC session ends mid-render.

### 2. `ReownAppKitModal.closeModal` — disposed Navigator context
```
TypeError: Null check operator used on a null value
  at ReownAppKitModal.closeModal (lib/modal/appkit_modal_impl.dart:1407)
  at Navigator.of (navigator.dart:2919)
  at StatefulElement.state (framework.dart:5938)
```
`Navigator.of(_context!, rootNavigator: true).canPop()` crashes because the cached `_context`'s element has been deactivated/disposed (`StatefulElement.state` returns null) by the time the user taps the close button after disconnect.

## Fix

* **`receive_page.dart`** — read `selectedChain` once; if null, return an empty `ModalNavbar` shell. The disconnect flow closes the modal asynchronously.
* **`appkit_modal_impl.dart`** — switch to `Navigator.maybeOf` and wrap `canPop()`/`pop()` in `try`/`catch` so `closeModal` is a no-op when the navigator tree is no longer reachable.

Both changes are defensive — no behaviour change on the happy path.

## Repro

Open WC modal → trigger session disconnect (e.g. from the wallet side or via `appKitModal.disconnect()`) while the Receive page is visible → either crash fires within ~10s.