### PR TITLE
feat(walletkit): add Solana support to WPay flow

### DIFF
--- a/packages/reown_walletkit/example/ios/Podfile.lock
+++ b/packages/reown_walletkit/example/ios/Podfile.lock
@@ -14,7 +14,7 @@ PODS:
     - MTBBarcodeScanner
   - reown_yttrium_utils (0.0.1):
     - Flutter
-    - YttriumUtilsWrapper (= 0.10.50)
+    - YttriumUtilsWrapper (= 0.10.54)
   - Sentry/HybridSDK (8.58.2)
   - sentry_flutter (9.20.0):
     - Flutter
@@ -34,7 +34,7 @@ PODS:
   - webview_flutter_wkwebview (0.0.1):
     - Flutter
     - FlutterMacOS
-  - YttriumUtilsWrapper (0.10.50)
+  - YttriumUtilsWrapper (0.10.54)
   - YttriumWrapper (0.10.50)
 
 DEPENDENCIES:
@@ -95,7 +95,7 @@ SPEC CHECKSUMS:
   package_info_plus: af8e2ca6888548050f16fa2f1938db7b5a5df499
   qr_bar_code_scanner_dialog: a4cb7ad7201cbf8b888f3e6e58972b611ac43b28
   qr_code_scanner: d77f94ecc9abf96d9b9b8fc04ef13f611e5a147a
-  reown_yttrium_utils: 7e71901a2dcb0f4f7af766e325b25a7a22c07b1e
+  reown_yttrium_utils: a369c63bc0ad51ec5530e781f8e204192fe351a0
   Sentry: de29b881e83bd91cf99a927f82f1fd86bfb39db2
   sentry_flutter: cbb414ef141b64f901bc1ba32daa871349510ce4
   shared_preferences_foundation: 7036424c3d8ec98dfe75ff1667cb0cd531ec82bb
@@ -103,7 +103,7 @@ SPEC CHECKSUMS:
   url_launcher_ios: 7a95fa5b60cc718a708b8f2966718e93db0cef1b
   walletconnect_pay: 78e7baf83dd7974a0d9ae2cd70c7f11b7a53b2e2
   webview_flutter_wkwebview: 8ebf4fded22593026f7dbff1fbff31ea98573c8d
-  YttriumUtilsWrapper: de844e114bf30b248b5d8de6662bceac9c85ba2b
+  YttriumUtilsWrapper: 6ef73adb996f91da5250e35e12e3684d3024e275
   YttriumWrapper: d7f63336830536f1da41b745ed8bacedb04228c4
 
 PODFILE CHECKSUM: f15d300013bf3f49206576bb82c1d46cc60fd0fe

--- a/packages/reown_walletkit/example/ios/Podfile.lock
+++ b/packages/reown_walletkit/example/ios/Podfile.lock
@@ -15,11 +15,11 @@ PODS:
   - reown_yttrium_utils (0.0.1):
     - Flutter
     - YttriumUtilsWrapper (= 0.10.54)
-  - Sentry/HybridSDK (8.58.2)
-  - sentry_flutter (9.20.0):
+  - Sentry/HybridSDK (8.58.3)
+  - sentry_flutter (9.21.0):
     - Flutter
     - FlutterMacOS
-    - Sentry/HybridSDK (= 8.58.2)
+    - Sentry/HybridSDK (= 8.58.3)
   - shared_preferences_foundation (0.0.1):
     - Flutter
     - FlutterMacOS
@@ -96,8 +96,8 @@ SPEC CHECKSUMS:
   qr_bar_code_scanner_dialog: a4cb7ad7201cbf8b888f3e6e58972b611ac43b28
   qr_code_scanner: d77f94ecc9abf96d9b9b8fc04ef13f611e5a147a
   reown_yttrium_utils: a369c63bc0ad51ec5530e781f8e204192fe351a0
-  Sentry: de29b881e83bd91cf99a927f82f1fd86bfb39db2
-  sentry_flutter: cbb414ef141b64f901bc1ba32daa871349510ce4
+  Sentry: 108fdbb76299c4189af12246bf0308c09c278922
+  sentry_flutter: 32e67cb4756ce3de42bbd56581fa935922ff328f
   shared_preferences_foundation: 7036424c3d8ec98dfe75ff1667cb0cd531ec82bb
   sqflite_darwin: 20b2a3a3b70e43edae938624ce550a3cbf66a3d0
   url_launcher_ios: 7a95fa5b60cc718a708b8f2966718e93db0cef1b

--- a/packages/reown_walletkit/example/lib/dependencies/chain_services/evm_service.dart
+++ b/packages/reown_walletkit/example/lib/dependencies/chain_services/evm_service.dart
@@ -7,7 +7,6 @@ import 'package:http/http.dart' as http;
 import 'package:get_it/get_it.dart';
 import 'package:eth_sig_util_plus/eth_sig_util_plus.dart' as eth_sig_util;
 import 'package:eth_sig_util_plus/util/utils.dart' as eth_sig_util_util;
-import 'package:package_info_plus/package_info_plus.dart';
 import 'package:reown_walletkit/reown_walletkit.dart';
 
 import 'package:reown_walletkit_wallet/dependencies/i_walletkit_service.dart';
@@ -748,57 +747,6 @@ class EVMService {
     );
 
     return signature;
-  }
-
-  Future<List<Map<String, dynamic>>> getBalance({
-    required String address,
-  }) async {
-    final uri = Uri.parse(
-      'https://rpc.walletconnect.org/v1/account/$address/balance',
-    );
-    final queryParams = {
-      'projectId': _walletKit.core.projectId,
-      'currency': 'usd',
-      // 'chainId': chainSupported.chainId,
-    };
-    final package = await PackageInfo.fromPlatform();
-    final response = await http.get(
-      uri.replace(queryParameters: queryParams),
-      headers: {
-        'Content-Type': 'application/json',
-        'x-sdk-type': 'flutter-sample-wallet',
-        'x-sdk-version': package.version,
-        'origin': package.packageName,
-      },
-    );
-    if (response.statusCode == 200 && response.body.isNotEmpty) {
-      try {
-        final jsonData = jsonDecode(response.body) as Map<String, dynamic>;
-        final balances = (jsonData['balances'] as List).map((e) {
-          return e as Map<String, dynamic>;
-        }).toList();
-        return balances
-          ..sort((a, b) {
-            // final bQuantity = double.tryParse(b['quantity']['numeric']) ?? 0.0;
-            // final aQuantity = double.tryParse(a['quantity']['numeric']) ?? 0.0;
-            final bQuantity = b['value'] as double? ?? 0.0;
-            final aQuantity = a['value'] as double? ?? 0.0;
-            return bQuantity.compareTo(aQuantity);
-          });
-      } catch (e) {
-        throw Exception('Failed to load balance. $e');
-      }
-    }
-    try {
-      final errorData = jsonDecode(response.body) as Map<String, dynamic>;
-      final reasons = errorData['reasons'] as List<dynamic>;
-      final reason = reasons.isNotEmpty
-          ? reasons.first['description'] ?? ''
-          : response.body;
-      throw Exception(reason);
-    } catch (e) {
-      rethrow;
-    }
   }
 
   // Validate signatures

--- a/packages/reown_walletkit/example/lib/dependencies/chain_services/solana_service.dart
+++ b/packages/reown_walletkit/example/lib/dependencies/chain_services/solana_service.dart
@@ -6,6 +6,7 @@ import 'package:http/http.dart' as http;
 import 'package:flutter/material.dart';
 import 'package:get_it/get_it.dart';
 import 'package:reown_walletkit/reown_walletkit.dart';
+import 'package:reown_yttrium_utils/reown_yttrium_utils.dart';
 
 import 'package:solana/solana.dart' as solana;
 import 'package:solana/encoder.dart' as solana_encoder;
@@ -45,17 +46,14 @@ class SolanaService {
       final params = parameters as Map<String, dynamic>;
       final message = params['message'].toString(); // base58 encoded message
 
-      final keyPair = await _getKeyPair();
+      final address = await _getAddress();
 
-      // it's being sent encoded from dapp
-      // final base58Decoded = base58.decode(message);
-      // final decodedMessage = utf8.decode(base58Decoded);
       final requester = _walletKit.sessions.get(pRequest.topic)?.peer;
       if (await MethodsUtils.requestApproval(
         message,
         method: pRequest.method,
         chainId: pRequest.chainId,
-        address: keyPair.address,
+        address: address,
         transportType: pRequest.transportType.name,
         requester: requester,
       )) {
@@ -81,10 +79,12 @@ class SolanaService {
   }
 
   Future<String> signMessage(String message) async {
-    final keyPair = await _getKeyPair();
-    final base58Decoded = base58.decode(message);
-    final signature = await keyPair.sign(base58Decoded.toList());
-    return signature.toBase58();
+    final keyPair = await _yttriumKeyPair();
+    final messageBytes = Uint8List.fromList(base58.decode(message).toList());
+    return await ReownYttriumUtils.solanaClient.signMessage(
+      keyPair: keyPair,
+      message: messageBytes,
+    );
   }
 
   Future<void> solanaSignTransaction(String topic, dynamic parameters) async {
@@ -98,34 +98,25 @@ class SolanaService {
       final params = parameters as Map<String, dynamic>;
       final beautifiedTrx = const JsonEncoder.withIndent('  ').convert(params);
 
-      final keyPair = await _getKeyPair();
+      final address = await _getAddress();
 
       final requester = _walletKit.sessions.get(pRequest.topic)?.peer;
       if (await MethodsUtils.requestApproval(
         beautifiedTrx,
         method: pRequest.method,
         chainId: pRequest.chainId,
-        address: keyPair.address,
+        address: address,
         transportType: pRequest.transportType.name,
         requester: requester,
       )) {
-        // Sign the transaction.
-        // if params contains `transaction` key we should parse that one and disregard the rest
+        // Build a base64-encoded VersionedTransaction for yttrium. Branch 1
+        // (modern WC RPC) gets it directly. Branch 2 (legacy feePayer+
+        // instructions form) compiles a Message via the solana package, then
+        // wraps it in a SignedTx so yttrium can populate the signature.
+        final String base64Tx;
         if (params.containsKey('transaction')) {
-          final transaction = params['transaction'] as String;
-          final transactionBytes = base64.decode(transaction);
-          final signedTx = solana_encoder.SignedTx.fromBytes(transactionBytes);
-
-          // Sign the transaction.
-          final signature = await keyPair.sign(
-            signedTx.compiledMessage.toByteArray(),
-          );
-
-          response = response.copyWith(
-            result: {'signature': signature.toBase58()},
-          );
+          base64Tx = params['transaction'] as String;
         } else {
-          // else we parse the other key/values, see https://docs.walletconnect.com/advanced/multichain/rpc-reference/solana-rpc#solana_signtransaction
           final feePayer = params['feePayer'].toString();
           final recentBlockHash = params['recentBlockhash'].toString();
           final instructionsList = params['instructions'] as List<dynamic>;
@@ -139,14 +130,27 @@ class SolanaService {
             recentBlockhash: recentBlockHash,
             feePayer: solana.Ed25519HDPublicKey.fromBase58(feePayer),
           );
-
-          // Sign the transaction.
-          final signature = await keyPair.sign(compiledMessage.toByteArray());
-
-          response = response.copyWith(
-            result: {'signature': signature.toBase58()},
+          // Empty/placeholder signature so the wire format is well-formed;
+          // yttrium will overwrite it at the correct signer slot.
+          final placeholder = solana_encoder.Signature(
+            List.filled(64, 0),
+            publicKey: solana.Ed25519HDPublicKey.fromBase58(feePayer),
           );
+          final unsignedTx = solana_encoder.SignedTx(
+            signatures: [placeholder],
+            compiledMessage: compiledMessage,
+          );
+          base64Tx = base64.encode(unsignedTx.toByteArray().toList());
         }
+
+        final signed = await ReownYttriumUtils.solanaClient.signTransaction(
+          keyPair: await _yttriumKeyPair(),
+          transaction: base64Tx,
+        );
+
+        response = response.copyWith(
+          result: {'signature': signed.signature},
+        );
       } else {
         final error = Errors.getSdkError(Errors.USER_REJECTED);
         response = response.copyWith(
@@ -178,36 +182,28 @@ class SolanaService {
       final params = parameters as Map<String, dynamic>;
       final beautifiedTrx = const JsonEncoder.withIndent('  ').convert(params);
 
-      final keyPair = await _getKeyPair();
+      final address = await _getAddress();
 
       final requester = _walletKit.sessions.get(pRequest.topic)?.peer;
       if (await MethodsUtils.requestApproval(
         beautifiedTrx,
         method: pRequest.method,
         chainId: pRequest.chainId,
-        address: keyPair.address,
+        address: address,
         transportType: pRequest.transportType.name,
         requester: requester,
       )) {
         if (params.containsKey('transactions')) {
-          final transactions = params['transactions'] as List;
-
-          List<String> signedTransactions = [];
-          for (var transaction in transactions) {
-            final transactionBytes = base64.decode(transaction);
-            final unsignedTx = solana_encoder.SignedTx.fromBytes(
-              transactionBytes,
-            );
-            final signature = await keyPair.sign(
-              unsignedTx.compiledMessage.toByteArray(),
-            );
-            final signedTx = unsignedTx.copyWith(signatures: [signature]);
-            final reEncodedTx = signedTx.encode();
-            signedTransactions.add(reEncodedTx);
-          }
-
+          final transactions = (params['transactions'] as List).cast<String>();
+          final signed = await ReownYttriumUtils.solanaClient
+              .signAllTransactions(
+                keyPair: await _yttriumKeyPair(),
+                transactions: transactions,
+              );
           response = response.copyWith(
-            result: {'transactions': signedTransactions},
+            result: {
+              'transactions': signed.map((s) => s.transaction).toList(),
+            },
           );
         }
       } else {
@@ -227,12 +223,22 @@ class SolanaService {
     _handleResponseForTopic(topic, response);
   }
 
-  Future<solana.Ed25519HDKeyPair> _getKeyPair() async {
+  /// Returns the base58-encoded yttrium-compatible keypair (priv32 || pub32).
+  /// Storage format from `_solanaChainKey` is `privateBytes(32) || publicBytes(32)`
+  /// hex-encoded — yttrium's `SolanaKeypair` is the same 64-byte layout, just
+  /// base58. Pure encoding swap, no on-device migration.
+  Future<String> yttriumKeyPair() => _yttriumKeyPair();
+
+  Future<String> _yttriumKeyPair() async {
     final keys = GetIt.I<IKeyService>().getKeysForChain(chainSupported.chainId);
-    final secKeyBytes = keys[0].privateKey.parse32Bytes();
-    return await solana.Ed25519HDKeyPair.fromPrivateKeyBytes(
-      privateKey: secKeyBytes,
-    );
+    final stored = keys[0].privateKey;
+    final keyPairBytes = Uint8List.fromList(hex.decode(stored));
+    return base58.encode(keyPairBytes);
+  }
+
+  Future<String> _getAddress() async {
+    final keys = GetIt.I<IKeyService>().getKeysForChain(chainSupported.chainId);
+    return keys[0].address;
   }
 
   void _handleResponseForTopic(String topic, JsonRpcResponse response) async {
@@ -303,41 +309,6 @@ class SolanaService {
       }
     } catch (e) {
       rethrow;
-    }
-  }
-}
-
-extension on String {
-  // SigningKey used by solana package requires a 32 bytes key
-  Uint8List parse32Bytes() {
-    // Try comma-separated integers first (legacy format)
-    if (contains(',')) {
-      try {
-        final List<int> secBytes = split(',').map((e) => int.parse(e)).toList();
-        return Uint8List.fromList(secBytes.sublist(0, 32));
-      } catch (_) {}
-    }
-
-    // Try hex decoding (stored format from _solanaChainKey is hex-encoded)
-    // Check if it looks like hex: even length, only hex characters
-    if (length % 2 == 0 && RegExp(r'^[0-9a-fA-F]+$').hasMatch(this)) {
-      try {
-        final secKeyBytes = hex.decode(this);
-        // Extract first 32 bytes (private key)
-        // Stored format from _solanaChainKey is privateBytes(32) + publicBytes(32) = 64 bytes = 128 hex chars
-        // But also handle case where only private key is stored = 32 bytes = 64 hex chars
-        return Uint8List.fromList(secKeyBytes.sublist(0, 32));
-      } catch (_) {}
-    }
-
-    // Fallback to base58 decoding
-    try {
-      final secKeyBytes = base58.decode(this);
-      return Uint8List.fromList(secKeyBytes.sublist(0, 32));
-    } catch (e) {
-      throw FormatException(
-        'Unable to parse private key. Expected comma-separated integers, hex string, or base58 string.',
-      );
     }
   }
 }

--- a/packages/reown_walletkit/example/lib/dependencies/chain_services/solana_service.dart
+++ b/packages/reown_walletkit/example/lib/dependencies/chain_services/solana_service.dart
@@ -223,11 +223,16 @@ class SolanaService {
     _handleResponseForTopic(topic, response);
   }
 
-  /// Returns the base58-encoded yttrium-compatible keypair (priv32 || pub32).
-  /// Storage format from `_solanaChainKey` is `privateBytes(32) || publicBytes(32)`
-  /// hex-encoded — yttrium's `SolanaKeypair` is the same 64-byte layout, just
-  /// base58. Pure encoding swap, no on-device migration.
-  Future<String> yttriumKeyPair() => _yttriumKeyPair();
+  /// Signs a Pay-flow `solana_signTransaction` action and returns the
+  /// base64-encoded signed transaction blob (what the Pay backend wants in
+  /// `confirmPayment.signatures` so it can broadcast).
+  Future<String> signPayTransaction(String base64Transaction) async {
+    final signed = await ReownYttriumUtils.solanaClient.signTransaction(
+      keyPair: await _yttriumKeyPair(),
+      transaction: base64Transaction,
+    );
+    return signed.transaction;
+  }
 
   Future<String> _yttriumKeyPair() async {
     final keys = GetIt.I<IKeyService>().getKeysForChain(chainSupported.chainId);

--- a/packages/reown_walletkit/example/lib/dependencies/walletkit_service.dart
+++ b/packages/reown_walletkit/example/lib/dependencies/walletkit_service.dart
@@ -268,8 +268,15 @@ class WalletKitService implements IWalletKitService {
 
   Future<void> processPayment(String paymentLink) async {
     try {
-      // PaymentOptionsResponse
-      final accounts = await getWalletAccounts('eip155');
+      // PaymentOptionsResponse. Pay backend only accepts Solana mainnet
+      // (5eykt4...) — sending devnet/testnet chain ids trips its CAIP-10
+      // validator, so filter to mainnet only.
+      const solanaMainnet = 'solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp';
+      final accounts = [
+        ...await getWalletAccounts('eip155'),
+        ...(await getWalletAccounts('solana'))
+            .where((a) => a.startsWith('$solanaMainnet:')),
+      ];
       final optionsResponse = await _bottomSheetHandler.queueBottomSheet(
         widget: WCPGetPaymentOptions(
           paymentLink: paymentLink,

--- a/packages/reown_walletkit/example/lib/pages/balances_page.dart
+++ b/packages/reown_walletkit/example/lib/pages/balances_page.dart
@@ -1,12 +1,12 @@
 import 'package:cached_network_image/cached_network_image.dart';
 import 'package:flutter/material.dart';
 import 'package:get_it/get_it.dart';
-import 'package:reown_walletkit_wallet/dependencies/chain_services/evm_service.dart';
 import 'package:reown_walletkit_wallet/dependencies/i_walletkit_service.dart';
 import 'package:reown_walletkit_wallet/dependencies/key_service/i_key_service.dart';
 import 'package:reown_walletkit_wallet/models/chain_data.dart';
 import 'package:reown_walletkit_wallet/theme/app_colors.dart';
 import 'package:reown_walletkit_wallet/theme/app_spacing.dart';
+import 'package:reown_walletkit_wallet/utils/blockchain_api_utils.dart';
 
 class BalancesPage extends StatefulWidget {
   const BalancesPage({super.key});
@@ -71,11 +71,27 @@ class _BalancesPageState extends State<BalancesPage> {
       final selectedChain = _walletKitService.currentSelectedChain.value ??
           ChainsDataList.eip155Chains.first;
       final chainKey = chainKeys.first;
-      final evmService = _walletKitService.getChainService<EVMService>(
-        chainId: selectedChain.chainId,
-      );
 
-      final balances = await evmService.getBalance(address: chainKey.address);
+      final solanaKeys = _keysService.getKeysForChain('solana');
+      final balanceFutures = <Future<List<Map<String, dynamic>>>>[
+        BlockchainApiUtils.getBalance(
+          address: chainKey.address,
+          chainId: selectedChain.chainId,
+        ),
+        if (solanaKeys.isNotEmpty)
+          BlockchainApiUtils.getBalance(
+            address: solanaKeys.first.address,
+            chainId: 'solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp',
+          ),
+      ];
+      final balances = (await Future.wait(balanceFutures, eagerError: false))
+          .expand((r) => r)
+          .toList()
+        ..sort((a, b) {
+          final bValue = b['value'] as double? ?? 0.0;
+          final aValue = a['value'] as double? ?? 0.0;
+          return bValue.compareTo(aValue);
+        });
 
       if (!mounted) return;
       setState(() {

--- a/packages/reown_walletkit/example/lib/pages/balances_page.dart
+++ b/packages/reown_walletkit/example/lib/pages/balances_page.dart
@@ -79,10 +79,11 @@ class _BalancesPageState extends State<BalancesPage> {
           chainId: selectedChain.chainId,
         ),
         if (solanaKeys.isNotEmpty)
+          // Fail-soft: a Solana balance error shouldn't wipe EVM balances.
           BlockchainApiUtils.getBalance(
             address: solanaKeys.first.address,
             chainId: 'solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp',
-          ),
+          ).catchError((_) => <Map<String, dynamic>>[]),
       ];
       final balances = (await Future.wait(balanceFutures, eagerError: false))
           .expand((r) => r)

--- a/packages/reown_walletkit/example/lib/pages/secret_keys_page.dart
+++ b/packages/reown_walletkit/example/lib/pages/secret_keys_page.dart
@@ -135,10 +135,11 @@ class _EVMAccountsState extends State<_EVMAccounts> {
         chainId: _selectedChain.chainId,
       ),
       if (solanaKeys.isNotEmpty)
+        // Fail-soft: a Solana balance error shouldn't wipe EVM balances.
         BlockchainApiUtils.getBalance(
           address: solanaKeys.first.address,
           chainId: 'solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp',
-        ),
+        ).catchError((_) => <Map<String, dynamic>>[]),
     ];
 
     Future.wait(futures, eagerError: false)

--- a/packages/reown_walletkit/example/lib/pages/secret_keys_page.dart
+++ b/packages/reown_walletkit/example/lib/pages/secret_keys_page.dart
@@ -5,7 +5,6 @@ import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:get_it/get_it.dart';
 import 'package:reown_walletkit/reown_walletkit.dart';
-import 'package:reown_walletkit_wallet/dependencies/chain_services/evm_service.dart';
 import 'package:reown_walletkit_wallet/dependencies/chain_services/tron_service.dart';
 import 'package:reown_walletkit_wallet/dependencies/i_walletkit_service.dart';
 import 'package:reown_walletkit_wallet/dependencies/key_service/chain_key.dart';
@@ -15,6 +14,7 @@ import 'package:reown_walletkit_wallet/models/chain_metadata.dart';
 import 'package:reown_walletkit_wallet/theme/app_colors.dart';
 import 'package:reown_walletkit_wallet/theme/app_radius.dart';
 import 'package:reown_walletkit_wallet/theme/app_spacing.dart';
+import 'package:reown_walletkit_wallet/utils/blockchain_api_utils.dart';
 import 'package:toastification/toastification.dart';
 
 class SecretKeysPage extends StatelessWidget {
@@ -125,20 +125,40 @@ class _EVMAccountsState extends State<_EVMAccounts> {
     if (!mounted) return;
     final chainKeys = _keysService.getKeysForChain('eip155');
     final chainKey = chainKeys[_currentPage];
-    final evmService = _walletKitService.getChainService<EVMService>(
-      chainId: _selectedChain.chainId,
-    );
-    evmService.getBalance(address: chainKey.address).then((balances) {
-      if (!mounted) return;
-      _balances
-        ..clear()
-        ..addAll(balances);
-      setState(() {});
-    }).onError((a, b) {
-      if (!mounted) return;
-      _balances.clear();
-      setState(() {});
-    });
+
+    // `/v1/account/{address}/balance` takes one address per call, so we
+    // fire one request per namespace and union the results.
+    final solanaKeys = _keysService.getKeysForChain('solana');
+    final futures = <Future<List<Map<String, dynamic>>>>[
+      BlockchainApiUtils.getBalance(
+        address: chainKey.address,
+        chainId: _selectedChain.chainId,
+      ),
+      if (solanaKeys.isNotEmpty)
+        BlockchainApiUtils.getBalance(
+          address: solanaKeys.first.address,
+          chainId: 'solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp',
+        ),
+    ];
+
+    Future.wait(futures, eagerError: false)
+        .then((results) {
+          if (!mounted) return;
+          _balances
+            ..clear()
+            ..addAll(results.expand((r) => r));
+          _balances.sort((a, b) {
+            final bValue = b['value'] as double? ?? 0.0;
+            final aValue = a['value'] as double? ?? 0.0;
+            return bValue.compareTo(aValue);
+          });
+          setState(() {});
+        })
+        .onError((a, b) {
+          if (!mounted) return;
+          _balances.clear();
+          setState(() {});
+        });
     setState(() => {});
   }
 

--- a/packages/reown_walletkit/example/lib/utils/blockchain_api_utils.dart
+++ b/packages/reown_walletkit/example/lib/utils/blockchain_api_utils.dart
@@ -1,0 +1,62 @@
+import 'dart:convert';
+
+import 'package:get_it/get_it.dart';
+import 'package:http/http.dart' as http;
+import 'package:package_info_plus/package_info_plus.dart';
+import 'package:reown_walletkit_wallet/dependencies/i_walletkit_service.dart';
+
+class BlockchainApiUtils {
+  static const _balancePath = 'https://rpc.walletconnect.org/v1/account';
+
+  /// Fetches balances for [address] on [chainId] via the Reown blockchain
+  /// API. Works across namespaces — `eip155:1`, `solana:5eykt4Us…`, etc.
+  /// The path takes a single address per call.
+  static Future<List<Map<String, dynamic>>> getBalance({
+    required String address,
+    required String chainId,
+  }) async {
+    final walletKit = GetIt.I<IWalletKitService>().walletKit;
+    final uri = Uri.parse('$_balancePath/$address/balance');
+    final queryParams = {
+      'projectId': walletKit.core.projectId,
+      'currency': 'usd',
+      'chainId': chainId,
+    };
+    final package = await PackageInfo.fromPlatform();
+    final response = await http.get(
+      uri.replace(queryParameters: queryParams),
+      headers: {
+        'Content-Type': 'application/json',
+        'x-sdk-type': 'flutter-sample-wallet',
+        'x-sdk-version': package.version,
+        'origin': package.packageName,
+      },
+    );
+    if (response.statusCode == 200 && response.body.isNotEmpty) {
+      try {
+        final jsonData = jsonDecode(response.body) as Map<String, dynamic>;
+        final balances = (jsonData['balances'] as List).map((e) {
+          return e as Map<String, dynamic>;
+        }).toList();
+        return balances
+          ..sort((a, b) {
+            final bValue = b['value'] as double? ?? 0.0;
+            final aValue = a['value'] as double? ?? 0.0;
+            return bValue.compareTo(aValue);
+          });
+      } catch (e) {
+        throw Exception('Failed to load balance. $e');
+      }
+    }
+    try {
+      final errorData = jsonDecode(response.body) as Map<String, dynamic>;
+      final reasons = errorData['reasons'] as List<dynamic>;
+      final reason = reasons.isNotEmpty
+          ? reasons.first['description'] ?? ''
+          : response.body;
+      throw Exception(reason);
+    } catch (e) {
+      rethrow;
+    }
+  }
+}

--- a/packages/reown_walletkit/example/lib/walletconnect_pay/wcp_modals/wcp_confirming_payment.dart
+++ b/packages/reown_walletkit/example/lib/walletconnect_pay/wcp_modals/wcp_confirming_payment.dart
@@ -4,11 +4,13 @@ import 'package:flutter/material.dart' hide Action;
 import 'package:get_it/get_it.dart';
 import 'package:reown_walletkit/reown_walletkit.dart';
 import 'package:reown_walletkit_wallet/dependencies/chain_services/evm_service.dart';
+import 'package:reown_walletkit_wallet/dependencies/chain_services/solana_service.dart';
 import 'package:reown_walletkit_wallet/dependencies/i_walletkit_service.dart';
 import 'package:reown_walletkit_wallet/theme/app_colors.dart';
 import 'package:reown_walletkit_wallet/theme/app_radius.dart';
 import 'package:reown_walletkit_wallet/theme/app_spacing.dart';
 import 'package:reown_walletkit_wallet/walletconnect_pay/wcp_shared_widgets.dart';
+import 'package:reown_yttrium_utils/reown_yttrium_utils.dart';
 
 typedef WCPActionExecutor = Future<String> Function(Action action);
 
@@ -106,22 +108,47 @@ class _WCPConfirmingPaymentState extends State<WCPConfirmingPayment> {
     final method = action.walletRpc.method;
     final chainId = action.walletRpc.chainId;
     final params = action.walletRpc.params;
-    final service = _walletKitService.getChainService<EVMService>(
-      chainId: chainId,
-    );
 
     switch (method) {
       case 'eth_signTypedData_v4':
         final decoded = jsonDecode(params) as List<dynamic>;
         final typedData = _ensureEip712Domain(decoded.last);
-        return service.ethSignTypedDataV4(typedData);
+        return _walletKitService
+            .getChainService<EVMService>(chainId: chainId)
+            .ethSignTypedDataV4(typedData);
       case 'eth_sendTransaction':
         final decoded = jsonDecode(params) as List<dynamic>;
         final txParams = Map<String, dynamic>.from(decoded.first as Map);
-        return service.sendPayTransaction(txParams);
+        return _walletKitService
+            .getChainService<EVMService>(chainId: chainId)
+            .sendPayTransaction(txParams);
+      case 'solana_signTransaction':
+        final solanaService = _walletKitService.getChainService<SolanaService>(
+          chainId: chainId,
+        );
+        final txParams = _parseSolanaPayParams(params);
+        final base64Tx = txParams['transaction'] as String;
+        final signed = await ReownYttriumUtils.solanaClient.signTransaction(
+          keyPair: await solanaService.yttriumKeyPair(),
+          transaction: base64Tx,
+        );
+        // Pay backend wants the base64-encoded signed transaction blob
+        // (not the bare signature) so it can broadcast.
+        return signed.transaction;
       default:
         throw UnimplementedError('Unsupported pay method: $method');
     }
+  }
+
+  // The Pay backend may serialize Solana params as either the bare WC object
+  // `{transaction}` or wrapped in a single-element array `[{transaction}]`.
+  // Unwrap the array form transparently.
+  Map<String, dynamic> _parseSolanaPayParams(String params) {
+    final decoded = jsonDecode(params);
+    if (decoded is List) {
+      return Map<String, dynamic>.from(decoded.first as Map);
+    }
+    return Map<String, dynamic>.from(decoded as Map);
   }
 
   // eth_sig_util_plus requires an EIP712Domain entry in `types`. The Permit2

--- a/packages/reown_walletkit/example/lib/walletconnect_pay/wcp_modals/wcp_confirming_payment.dart
+++ b/packages/reown_walletkit/example/lib/walletconnect_pay/wcp_modals/wcp_confirming_payment.dart
@@ -10,7 +10,6 @@ import 'package:reown_walletkit_wallet/theme/app_colors.dart';
 import 'package:reown_walletkit_wallet/theme/app_radius.dart';
 import 'package:reown_walletkit_wallet/theme/app_spacing.dart';
 import 'package:reown_walletkit_wallet/walletconnect_pay/wcp_shared_widgets.dart';
-import 'package:reown_yttrium_utils/reown_yttrium_utils.dart';
 
 typedef WCPActionExecutor = Future<String> Function(Action action);
 
@@ -127,14 +126,9 @@ class _WCPConfirmingPaymentState extends State<WCPConfirmingPayment> {
           chainId: chainId,
         );
         final txParams = _parseSolanaPayParams(params);
-        final base64Tx = txParams['transaction'] as String;
-        final signed = await ReownYttriumUtils.solanaClient.signTransaction(
-          keyPair: await solanaService.yttriumKeyPair(),
-          transaction: base64Tx,
+        return solanaService.signPayTransaction(
+          txParams['transaction'] as String,
         );
-        // Pay backend wants the base64-encoded signed transaction blob
-        // (not the bare signature) so it can broadcast.
-        return signed.transaction;
       default:
         throw UnimplementedError('Unsupported pay method: $method');
     }

--- a/packages/reown_yttrium_utils/android/build.gradle
+++ b/packages/reown_yttrium_utils/android/build.gradle
@@ -78,7 +78,7 @@ android {
 }
 
 dependencies {
-    implementation("com.github.reown-com.yttrium:yttrium-utils:0.10.51") {
+    implementation("com.github.reown-com.yttrium:yttrium-utils:0.10.54") {
         exclude(group: 'net.java.dev.jna', module: 'jna')
     }
     implementation("net.java.dev.jna:jna:5.17.0@aar")

--- a/packages/reown_yttrium_utils/android/build.gradle
+++ b/packages/reown_yttrium_utils/android/build.gradle
@@ -78,7 +78,7 @@ android {
 }
 
 dependencies {
-    implementation("com.github.reown-com.yttrium:yttrium-utils:0.10.54") {
+    implementation("com.github.reown-com.yttrium:yttrium-utils:0.10.55") {
         exclude(group: 'net.java.dev.jna', module: 'jna')
     }
     implementation("net.java.dev.jna:jna:5.17.0@aar")

--- a/packages/reown_yttrium_utils/android/build.gradle
+++ b/packages/reown_yttrium_utils/android/build.gradle
@@ -78,7 +78,7 @@ android {
 }
 
 dependencies {
-    implementation("com.github.reown-com.yttrium:yttrium-utils:0.10.55") {
+    implementation("com.github.reown-com.yttrium:yttrium-utils:0.10.56") {
         exclude(group: 'net.java.dev.jna', module: 'jna')
     }
     implementation("net.java.dev.jna:jna:5.17.0@aar")

--- a/packages/reown_yttrium_utils/android/src/main/kotlin/com/reown/reown_yttrium_utils/ReownYttriumUtilsPlugin.kt
+++ b/packages/reown_yttrium_utils/android/src/main/kotlin/com/reown/reown_yttrium_utils/ReownYttriumUtilsPlugin.kt
@@ -38,6 +38,12 @@ class ReownYttriumUtilsPlugin: FlutterPlugin, MethodCallHandler {
       // "stx_estimateFees" -> Stacks.estimateFees(call.arguments, result)
       // "stx_getNonce" -> Stacks.getNonce(call.arguments, result)
       "stx_dispose" -> Stacks.dispose(call.arguments, result)
+      // === SOLANA METHODS ===
+      "solana_generateKeyPair" -> Solana.generateKeyPair(result)
+      "solana_getPublicKey" -> Solana.getPublicKey(call.arguments, result)
+      "solana_signTransaction" -> Solana.signTransaction(call.arguments, result)
+      "solana_signAllTransactions" -> Solana.signAllTransactions(call.arguments, result)
+      "solana_signMessage" -> Solana.signMessage(call.arguments, result)
       // === SUI METHODS ===
       "sui_init" -> Sui.init(applicationContext, call.arguments, result)
       "sui_generateKeyPair" -> Sui.generateKeyPair(call.arguments, result)

--- a/packages/reown_yttrium_utils/android/src/main/kotlin/com/reown/reown_yttrium_utils/Solana.kt
+++ b/packages/reown_yttrium_utils/android/src/main/kotlin/com/reown/reown_yttrium_utils/Solana.kt
@@ -1,0 +1,97 @@
+package com.reown.reown_yttrium_utils
+
+import android.annotation.SuppressLint
+import android.util.Log
+import io.flutter.plugin.common.MethodChannel
+import uniffi.yttrium_utils.solanaGenerateKeypair
+import uniffi.yttrium_utils.solanaPubkeyForKeypair
+import uniffi.yttrium_utils.solanaSignAllTransactions
+import uniffi.yttrium_utils.solanaSignMessage
+import uniffi.yttrium_utils.solanaSignTransaction
+
+/**
+ * Solana.kt
+ *
+ * Thin wrapper around the yttrium-utils Solana UniFFI free functions
+ * (no per-network client state).
+ */
+object Solana {
+
+    fun generateKeyPair(result: MethodChannel.Result) {
+        try {
+            result.success(solanaGenerateKeypair())
+        } catch (e: Exception) {
+            result.error("Solana.generateKeyPair", e.message, null)
+        }
+    }
+
+    @SuppressLint("LongLogTag")
+    fun getPublicKey(params: Any?, result: MethodChannel.Result) {
+        val dict = params as? Map<*, *>
+            ?: return result.error("Solana.getPublicKey", "Invalid parameters", null)
+        val keyPair = dict["keyPair"] as? String
+            ?: return errorMissing("keyPair", params, result)
+        try {
+            result.success(solanaPubkeyForKeypair(keyPair))
+        } catch (e: Exception) {
+            result.error("Solana.getPublicKey", e.message, null)
+        }
+    }
+
+    fun signTransaction(params: Any?, result: MethodChannel.Result) {
+        val dict = params as? Map<*, *>
+            ?: return result.error("Solana.signTransaction", "Invalid parameters", null)
+        val keyPair = dict["keyPair"] as? String
+            ?: return errorMissing("keyPair", params, result)
+        val transaction = dict["transaction"] as? String
+            ?: return errorMissing("transaction", params, result)
+        try {
+            val signed = solanaSignTransaction(keyPair, transaction)
+            result.success(
+                mapOf(
+                    "transaction" to signed.transaction,
+                    "signature" to signed.signature,
+                )
+            )
+        } catch (e: Exception) {
+            Log.e("🤖 Solana.signTransaction", e.message ?: "unknown")
+            result.error("Solana.signTransaction", e.message, null)
+        }
+    }
+
+    fun signAllTransactions(params: Any?, result: MethodChannel.Result) {
+        val dict = params as? Map<*, *>
+            ?: return result.error("Solana.signAllTransactions", "Invalid parameters", null)
+        val keyPair = dict["keyPair"] as? String
+            ?: return errorMissing("keyPair", params, result)
+        @Suppress("UNCHECKED_CAST")
+        val transactions = dict["transactions"] as? List<String>
+            ?: return errorMissing("transactions", params, result)
+        try {
+            val signed = solanaSignAllTransactions(keyPair, transactions)
+            result.success(
+                signed.map { mapOf("transaction" to it.transaction, "signature" to it.signature) }
+            )
+        } catch (e: Exception) {
+            Log.e("🤖 Solana.signAllTransactions", e.message ?: "unknown")
+            result.error("Solana.signAllTransactions", e.message, null)
+        }
+    }
+
+    fun signMessage(params: Any?, result: MethodChannel.Result) {
+        val dict = params as? Map<*, *>
+            ?: return result.error("Solana.signMessage", "Invalid parameters", null)
+        val keyPair = dict["keyPair"] as? String
+            ?: return errorMissing("keyPair", params, result)
+        val message = dict["message"] as? ByteArray
+            ?: return errorMissing("message", params, result)
+        try {
+            // Yttrium's UniFFI `Bytes` custom type lifts from a `0x`-prefixed
+            // hex string (see uniffi::custom_type!(Bytes, String, ...)).
+            val hexMessage = "0x" + message.joinToString("") { "%02x".format(it) }
+            result.success(solanaSignMessage(keyPair, hexMessage))
+        } catch (e: Exception) {
+            result.error("Solana.signMessage", e.message, null)
+        }
+    }
+}

--- a/packages/reown_yttrium_utils/ios/Classes/Extensions.swift
+++ b/packages/reown_yttrium_utils/ios/Classes/Extensions.swift
@@ -33,8 +33,8 @@ extension Route {
         switch self {
         case .eip155(let txns):
             return (txns as [TxnDetails]).map { $0.toJson() } // list of TxnDetails
-//        case .solana(let txns):
-//            return (txns as [SolanaTxnDetails]).map { $0.toJson() } // list of SolanaTxnDetails
+        case .solana(let txns):
+            return (txns as [SolanaTxnDetails]).map { $0.toJson() } // list of SolanaTxnDetails
         }
     }
 }
@@ -59,8 +59,8 @@ extension Transactions {
         switch self {
         case .eip155(let txns):
             return (txns as [Transaction]).map { $0.toJson() } // list of Transaction
-//        case .solana(let txns):
-//            return (txns as [SolanaTransaction]).map { $0.toJson() } // list of SolanaTransaction
+        case .solana(let txns):
+            return (txns as [SolanaTransaction]).map { $0.toJson() } // list of SolanaTransaction
         }
     }
 }
@@ -87,6 +87,25 @@ extension Transaction {
             "input": input,
             "gasLimit": gasLimit,
             "nonce": nonce
+        ]
+    }
+}
+
+extension SolanaTransaction {
+    func toJson() -> [String: Any] {
+        return [
+            "chainId": chainId,
+            "from": from,
+            "transaction": transaction
+        ]
+    }
+}
+
+extension SolanaTxnDetails {
+    func toJson() -> [String: Any] {
+        return [
+            "transaction": transaction.toJson(),
+            "transactionHashToSign": transactionHashToSign
         ]
     }
 }

--- a/packages/reown_yttrium_utils/ios/Classes/ReownYttriumUtilsPlugin.swift
+++ b/packages/reown_yttrium_utils/ios/Classes/ReownYttriumUtilsPlugin.swift
@@ -33,6 +33,17 @@ public class ReownYttriumUtilsPlugin: NSObject, FlutterPlugin {
             Stacks.signMessage(call.arguments ?? {}, result: result)
         case "stx_transferStx":
             Stacks.transferStx(call.arguments ?? {}, result: result)
+            // === SOLANA METHODS ===
+        case "solana_generateKeyPair":
+            Solana.generateKeyPair(call.arguments ?? {}, result: result)
+        case "solana_getPublicKey":
+            Solana.getPublicKey(call.arguments ?? {}, result: result)
+        case "solana_signTransaction":
+            Solana.signTransaction(call.arguments ?? {}, result: result)
+        case "solana_signAllTransactions":
+            Solana.signAllTransactions(call.arguments ?? {}, result: result)
+        case "solana_signMessage":
+            Solana.signMessage(call.arguments ?? {}, result: result)
             // === SUI METHODS ===
         case "sui_init":
             Sui.initialize(call.arguments ?? {}, result: result)

--- a/packages/reown_yttrium_utils/ios/Classes/Solana.swift
+++ b/packages/reown_yttrium_utils/ios/Classes/Solana.swift
@@ -1,0 +1,74 @@
+import Flutter
+import UIKit
+import YttriumUtilsWrapper
+
+/**
+ * Solana.swift
+ *
+ * Thin wrapper around the yttrium-utils Solana UniFFI free functions
+ * (no per-network client state).
+ */
+class Solana {
+    static func generateKeyPair(_ params: Any, result: @escaping FlutterResult) {
+        result(solanaGenerateKeypair())
+    }
+
+    static func getPublicKey(_ params: Any, result: @escaping FlutterResult) {
+        guard let dict = params as? [String: Any],
+              let keyPair = dict["keyPair"] as? String else {
+            result(FlutterError(code: "Solana.getPublicKey", message: "Invalid parameters", details: params))
+            return
+        }
+        do {
+            result(try solanaPubkeyForKeypair(keypair: keyPair))
+        } catch {
+            result(FlutterError(code: "Solana.getPublicKey", message: error.localizedDescription, details: nil))
+        }
+    }
+
+    static func signTransaction(_ params: Any, result: @escaping FlutterResult) {
+        guard let dict = params as? [String: Any],
+              let keyPair = dict["keyPair"] as? String,
+              let transaction = dict["transaction"] as? String else {
+            result(FlutterError(code: "Solana.signTransaction", message: "Invalid parameters", details: params))
+            return
+        }
+        do {
+            let signed = try solanaSignTransaction(keypair: keyPair, transaction: transaction)
+            result([
+                "transaction": signed.transaction,
+                "signature": signed.signature,
+            ])
+        } catch {
+            result(FlutterError(code: "Solana.signTransaction", message: error.localizedDescription, details: nil))
+        }
+    }
+
+    static func signAllTransactions(_ params: Any, result: @escaping FlutterResult) {
+        guard let dict = params as? [String: Any],
+              let keyPair = dict["keyPair"] as? String,
+              let transactions = dict["transactions"] as? [String] else {
+            result(FlutterError(code: "Solana.signAllTransactions", message: "Invalid parameters", details: params))
+            return
+        }
+        do {
+            let signed = try solanaSignAllTransactions(keypair: keyPair, transactions: transactions)
+            result(signed.map { ["transaction": $0.transaction, "signature": $0.signature] })
+        } catch {
+            result(FlutterError(code: "Solana.signAllTransactions", message: error.localizedDescription, details: nil))
+        }
+    }
+
+    static func signMessage(_ params: Any, result: @escaping FlutterResult) {
+        guard let dict = params as? [String: Any],
+              let keyPair = dict["keyPair"] as? String,
+              let messageData = dict["message"] as? FlutterStandardTypedData else {
+            result(FlutterError(code: "Solana.signMessage", message: "Invalid parameters", details: params))
+            return
+        }
+        // Yttrium's UniFFI `Bytes` custom type lifts from a `0x`-prefixed hex
+        // string (see uniffi::custom_type!(Bytes, String, ...)).
+        let hexMessage = "0x" + messageData.data.map { String(format: "%02x", $0) }.joined()
+        result(solanaSignMessage(keypair: keyPair, message: hexMessage))
+    }
+}

--- a/packages/reown_yttrium_utils/ios/reown_yttrium_utils.podspec
+++ b/packages/reown_yttrium_utils/ios/reown_yttrium_utils.podspec
@@ -15,7 +15,7 @@ A new Flutter plugin project.
   s.source           = { :path => '.' }
   s.source_files = 'Classes/**/*'
   s.dependency 'Flutter'
-  s.dependency 'YttriumUtilsWrapper', '0.10.50'
+  s.dependency 'YttriumUtilsWrapper', '0.10.54'
   # For local development, comment out version constraint
   #s.dependency 'YttriumUtilsWrapper'
   s.platform = :ios, '13.0'

--- a/packages/reown_yttrium_utils/lib/channels/solana_channel.dart
+++ b/packages/reown_yttrium_utils/lib/channels/solana_channel.dart
@@ -1,0 +1,94 @@
+import 'package:flutter/foundation.dart';
+import 'package:flutter/services.dart';
+
+class MethodChannelSolana {
+  @visibleForTesting
+  final methodChannel = const MethodChannel('reown_yttrium_utils');
+
+  Future<String> generateKeyPair() async {
+    try {
+      final result = await methodChannel.invokeMethod<String>(
+        'solana_generateKeyPair',
+      );
+      return result!;
+    } on PlatformException catch (e) {
+      debugPrint('[$runtimeType] solana_generateKeyPair $e');
+      rethrow;
+    }
+  }
+
+  Future<String> getPublicKey({required String keyPair}) async {
+    try {
+      final result = await methodChannel.invokeMethod<String>(
+        'solana_getPublicKey',
+        {'keyPair': keyPair},
+      );
+      return result!;
+    } on PlatformException catch (e) {
+      debugPrint('[$runtimeType] solana_getPublicKey $e');
+      rethrow;
+    }
+  }
+
+  /// Signs a base64-encoded `VersionedTransaction`.
+  /// Returns `(transaction, signature)` where `transaction` is the base64
+  /// blob with the signature populated and `signature` is base58.
+  Future<({String transaction, String signature})> signTransaction({
+    required String keyPair,
+    required String transaction,
+  }) async {
+    try {
+      final result = await methodChannel.invokeMethod<dynamic>(
+        'solana_signTransaction',
+        {'keyPair': keyPair, 'transaction': transaction},
+      );
+      final map = result as Map<Object?, Object?>;
+      return (
+        transaction: map['transaction'].toString(),
+        signature: map['signature'].toString(),
+      );
+    } on PlatformException catch (e) {
+      debugPrint('[$runtimeType] solana_signTransaction $e');
+      rethrow;
+    }
+  }
+
+  Future<List<({String transaction, String signature})>> signAllTransactions({
+    required String keyPair,
+    required List<String> transactions,
+  }) async {
+    try {
+      final result = await methodChannel.invokeMethod<List<dynamic>>(
+        'solana_signAllTransactions',
+        {'keyPair': keyPair, 'transactions': transactions},
+      );
+      return result!.map((e) {
+        final map = e as Map<Object?, Object?>;
+        return (
+          transaction: map['transaction'].toString(),
+          signature: map['signature'].toString(),
+        );
+      }).toList();
+    } on PlatformException catch (e) {
+      debugPrint('[$runtimeType] solana_signAllTransactions $e');
+      rethrow;
+    }
+  }
+
+  /// Returns a base58-encoded signature over the raw [message] bytes.
+  Future<String> signMessage({
+    required String keyPair,
+    required Uint8List message,
+  }) async {
+    try {
+      final result = await methodChannel.invokeMethod<String>(
+        'solana_signMessage',
+        {'keyPair': keyPair, 'message': message},
+      );
+      return result!;
+    } on PlatformException catch (e) {
+      debugPrint('[$runtimeType] solana_signMessage $e');
+      rethrow;
+    }
+  }
+}

--- a/packages/reown_yttrium_utils/lib/clients/solana_client.dart
+++ b/packages/reown_yttrium_utils/lib/clients/solana_client.dart
@@ -1,0 +1,45 @@
+import 'dart:typed_data';
+
+import 'package:reown_yttrium_utils/reown_yttrium_utils_method_channel.dart';
+
+class SolanaClient {
+  final _methodChannel = MethodChannelReownYttriumUtils();
+
+  Future<String> generateKeyPair() async {
+    return await _methodChannel.solanaChannel.generateKeyPair();
+  }
+
+  Future<String> getPublicKey({required String keyPair}) async {
+    return await _methodChannel.solanaChannel.getPublicKey(keyPair: keyPair);
+  }
+
+  Future<({String transaction, String signature})> signTransaction({
+    required String keyPair,
+    required String transaction,
+  }) async {
+    return await _methodChannel.solanaChannel.signTransaction(
+      keyPair: keyPair,
+      transaction: transaction,
+    );
+  }
+
+  Future<List<({String transaction, String signature})>> signAllTransactions({
+    required String keyPair,
+    required List<String> transactions,
+  }) async {
+    return await _methodChannel.solanaChannel.signAllTransactions(
+      keyPair: keyPair,
+      transactions: transactions,
+    );
+  }
+
+  Future<String> signMessage({
+    required String keyPair,
+    required Uint8List message,
+  }) async {
+    return await _methodChannel.solanaChannel.signMessage(
+      keyPair: keyPair,
+      message: message,
+    );
+  }
+}

--- a/packages/reown_yttrium_utils/lib/reown_yttrium_utils.dart
+++ b/packages/reown_yttrium_utils/lib/reown_yttrium_utils.dart
@@ -1,4 +1,5 @@
 import 'package:reown_yttrium_utils/clients/chain_abstraction_client.dart';
+import 'package:reown_yttrium_utils/clients/solana_client.dart';
 import 'package:reown_yttrium_utils/clients/stacks_client.dart';
 import 'package:reown_yttrium_utils/clients/sui_client.dart';
 import 'package:reown_yttrium_utils/clients/ton_client.dart';
@@ -15,4 +16,5 @@ class ReownYttriumUtils {
   static final tonClient = TonClient();
   static final stacksClient = StacksClient();
   static final suiClient = SuiClient();
+  static final solanaClient = SolanaClient();
 }

--- a/packages/reown_yttrium_utils/lib/reown_yttrium_utils_method_channel.dart
+++ b/packages/reown_yttrium_utils/lib/reown_yttrium_utils_method_channel.dart
@@ -1,4 +1,5 @@
 import 'package:reown_yttrium_utils/channels/chain_abstraction_channel.dart';
+import 'package:reown_yttrium_utils/channels/solana_channel.dart';
 import 'package:reown_yttrium_utils/channels/stacks_channel.dart';
 import 'package:reown_yttrium_utils/channels/sui_channel.dart';
 import 'package:reown_yttrium_utils/channels/ton_channel.dart';
@@ -19,4 +20,7 @@ class MethodChannelReownYttriumUtils extends ReownYttriumUtilsPlatform {
 
   @override
   MethodChannelSui get suiChannel => MethodChannelSui();
+
+  @override
+  MethodChannelSolana get solanaChannel => MethodChannelSolana();
 }

--- a/packages/reown_yttrium_utils/lib/reown_yttrium_utils_platform_interface.dart
+++ b/packages/reown_yttrium_utils/lib/reown_yttrium_utils_platform_interface.dart
@@ -1,5 +1,6 @@
 import 'package:plugin_platform_interface/plugin_platform_interface.dart';
 import 'package:reown_yttrium_utils/channels/chain_abstraction_channel.dart';
+import 'package:reown_yttrium_utils/channels/solana_channel.dart';
 import 'package:reown_yttrium_utils/channels/stacks_channel.dart';
 import 'package:reown_yttrium_utils/channels/sui_channel.dart';
 import 'package:reown_yttrium_utils/channels/ton_channel.dart';
@@ -31,4 +32,5 @@ abstract class ReownYttriumUtilsPlatform extends PlatformInterface {
   abstract final MethodChannelTon tonChannel;
   abstract final MethodChannelStacks stacksChannel;
   abstract final MethodChannelSui suiChannel;
+  abstract final MethodChannelSolana solanaChannel;
 }


### PR DESCRIPTION
## Summary

Adds Solana support to the WalletConnect Pay (WPay) flow in the WalletKit sample wallet by routing Solana signing through `yttrium-utils` (mirrors reown-kotlin#389 and react-native-examples#501).

Solana signing now goes through the new yttrium UniFFI surface from [yttrium#499](https://github.com/reown-com/yttrium/pull/499):
- **iOS** `YttriumUtilsWrapper`: `0.10.54` (CocoaPods trunk)
- **Android** `yttrium-utils`: `0.10.56` (JitPack)

## What's in here

### Plugin: `reown_yttrium_utils` — new Solana surface
- `ReownYttriumUtils.solanaClient` exposes `signTransaction`, `signAllTransactions`, `signMessage`, `generateKeyPair`, `getPublicKey`
- Dart channel/client + native wrappers for Android (`Solana.kt`) and iOS (`Solana.swift`)
- `Bytes` UniFFI custom type is `0x`-prefixed hex — native layers encode `signMessage` input accordingly
- iOS `Extensions.swift`: handle the new `Route.solana` / `Transactions.solana` switch arms (the iOS xcframework is now built with the `solana` feature)

### Sample wallet: route all Solana signing through yttrium
- `solana_service.dart`: replace the `solana` package's `keyPair.sign(...)` with `ReownYttriumUtils.solanaClient` for all three handlers (`solana_signMessage`, `solana_signTransaction`, `solana_signAllTransactions`). JSON-RPC return contracts preserved.
- **No on-device key migration**: the stored format (`privateBytes(32) || publicBytes(32)` hex-encoded, see `key_service.dart:_solanaChainKey`) is byte-compatible with yttrium's `SolanaKeypair`; we just re-encode as base58 at signing time.

### Sample wallet: WPay Solana path
- Include the Solana mainnet account in `getPaymentOptions(accounts: [...])` (mainnet only — the Pay backend rejects devnet/testnet via CAIP-10 validation)
- New `solana_signTransaction` case in `_executeAction` (handles both bare-object `{ transaction }` and array-wrapped `[{ transaction }]` param shapes per the RN PR)
- Signing stays inside `SolanaService.signPayTransaction(base64Tx)`; returns the base64 signed-transaction blob to `confirmPayment.signatures` so the backend can broadcast

### Tangential clean-up
- Solana balance now appears on the keys/balances pages (was EVM-only)
- `getBalance` moved out of `EVMService` into `BlockchainApiUtils` since the endpoint is namespace-agnostic — call passes `chainId` (e.g. `solana:5eykt4Us…`)

## Test plan
- [x] Yttrium published (iOS `YttriumUtilsWrapper 0.10.54`, Android `yttrium-utils 0.10.56`)
- [x] Android: paste a Solana-enabled Pay link → SOL option appears → signs → backend confirms success
- [x] iOS: same
- [x] EVM regression: existing Polygon USDC Pay flow still completes
- [x] WC dapp regression: dapp-side `solana_signTransaction` / `solana_signMessage` / `solana_signAllTransactions` still return the legacy `{'signature': …}` / `{'transactions': […]}` shape
- [x] Solana balance row visible on keys page
- [x] CI green (iOS + Android Pay e2e)

🤖 Generated with [Claude Code](https://claude.com/claude-code)