### PR TITLE
ci(walletkit): point Maestro pay actions at PR #92 SHA + harden iOS sim

### DIFF
--- a/.github/workflows/ci_e2e_pay_tests.yml
+++ b/.github/workflows/ci_e2e_pay_tests.yml
@@ -97,10 +97,10 @@ jobs:
             --split-per-abi
 
       - name: Copy Maestro Pay test flows
-        uses: WalletConnect/actions/maestro/pay-tests@afc741fbe638ca13cfc10de2ed59b064c2b59436
+        uses: WalletConnect/actions/maestro/pay-tests@52e0ab7755ca993bd829062278654ed12b2d471d
 
       - name: Install Maestro CLI
-        uses: WalletConnect/actions/maestro/setup@afc741fbe638ca13cfc10de2ed59b064c2b59436
+        uses: WalletConnect/actions/maestro/setup@52e0ab7755ca993bd829062278654ed12b2d471d
 
       - name: Setup Android SDK
         uses: android-actions/setup-android@v3
@@ -282,7 +282,15 @@ jobs:
       - name: Boot iOS simulator
         run: |
           xcrun simctl boot "iPhone 16" 2>/dev/null || true
-          xcrun simctl bootstatus "iPhone 16"
+          # Wait for FULL boot (-b) so the steps below don't race a not-ready simulator
+          xcrun simctl bootstatus "iPhone 16" -b
+          # Clear stale Shared Web Credentials / associated-domains state on the fresh
+          # boot BEFORE the app is installed, so the install-time applinks binding isn't
+          # wiped by a later reset (which would force a racy dev-mode AASA re-fetch and
+          # leave the Universal Link unresolved → openurl falls back to Safari).
+          xcrun simctl spawn booted swcutil reset || true
+          # Disable UIKit animations to reduce Maestro timing flakiness
+          xcrun simctl spawn booted defaults write com.apple.UIKit UIAnimationDragCoefficient 0 || true
 
       - name: Install app on simulator
         run: |
@@ -295,16 +303,31 @@ jobs:
           fi
           echo "Installing: $APP_PATH"
           xcrun simctl install booted "$APP_PATH"
+          # Prime the associated-domains cache for the pay Universal Link domains so
+          # swcd has a verified applinks entry by the time the deeplink flow runs.
+          for domain in pay.walletconnect.com staging.pay.walletconnect.com dev.pay.walletconnect.com lab.reown.com; do
+            xcrun simctl spawn booted swcutil dl -d "$domain" || true
+          done
+          sleep 3
+          # Dump the FULL association table (not grep-filtered): swcd's per-app/domain
+          # verdict is what tells us whether the Universal Link will resolve, so it must
+          # be visible in CI logs when the deeplink flow flakes.
+          echo "=== swcutil show (associated-domains state after install + priming) ==="
+          xcrun simctl spawn booted swcutil show 2>/dev/null || true
 
       - name: Copy Maestro Pay test flows
-        uses: WalletConnect/actions/maestro/pay-tests@afc741fbe638ca13cfc10de2ed59b064c2b59436
+        uses: WalletConnect/actions/maestro/pay-tests@52e0ab7755ca993bd829062278654ed12b2d471d
 
       - name: Install Maestro CLI
-        uses: WalletConnect/actions/maestro/setup@afc741fbe638ca13cfc10de2ed59b064c2b59436
+        uses: WalletConnect/actions/maestro/setup@52e0ab7755ca993bd829062278654ed12b2d471d
 
       - name: Run Maestro iOS tests
         id: maestro_ios
         run: |
+          # Snapshot the associated-domains verification state at run start — brackets the
+          # post-install dump above and shows swcd's verdict closer to the deeplink flow.
+          echo "=== swcutil show (Maestro run start) ==="
+          xcrun simctl spawn booted swcutil show 2>/dev/null || true
           maestro test \
             --env APP_ID=com.walletconnect.flutterwallet.internal \
             --env WPAY_CUSTOMER_KEY_SINGLE_NOKYC=${{ secrets.WPAY_CUSTOMER_KEY_SINGLE_NOKYC }} \

--- a/.github/workflows/ci_e2e_pay_tests.yml
+++ b/.github/workflows/ci_e2e_pay_tests.yml
@@ -259,6 +259,29 @@ jobs:
         working-directory: packages/reown_walletkit/example/ios
         run: pod install
 
+      # iOS resolves Universal Links via the AASA file, which it fetches through
+      # Apple's CDN — often stale/missing on a fresh simulator, so the link opens
+      # Safari instead of the wallet. Appending `?mode=developer` to each associated
+      # domain makes the simulator fetch the AASA directly from the origin server,
+      # bypassing the CDN. Patched only here (CI runner); the committed entitlements
+      # file is untouched, so release builds keep reading the clean file.
+      - name: Enable associated-domains developer mode (Maestro build only)
+        run: |
+          set -euo pipefail
+          PB=/usr/libexec/PlistBuddy
+          ENT=packages/reown_walletkit/example/ios/Runner/Runner.entitlements
+          KEY=":com.apple.developer.associated-domains"
+          i=0
+          while val=$("$PB" -c "Print $KEY:$i" "$ENT" 2>/dev/null); do
+            case "$val" in
+              applinks:*'?mode=developer') ;;
+              applinks:*) "$PB" -c "Set $KEY:$i ${val}?mode=developer" "$ENT" ;;
+            esac
+            i=$((i + 1))
+          done
+          echo "Patched applinks entries in $ENT:"
+          "$PB" -c "Print $KEY" "$ENT"
+
       - name: Build Runner.app via xcodebuild (automatic signing)
         id: build_ios
         working-directory: packages/reown_walletkit/example/ios
@@ -282,15 +305,12 @@ jobs:
       - name: Boot iOS simulator
         run: |
           xcrun simctl boot "iPhone 16" 2>/dev/null || true
-          # Wait for FULL boot (-b) so the steps below don't race a not-ready simulator
+          # Wait for full boot before configuring the simulator
           xcrun simctl bootstatus "iPhone 16" -b
-          # Clear stale Shared Web Credentials / associated-domains state on the fresh
-          # boot BEFORE the app is installed, so the install-time applinks binding isn't
-          # wiped by a later reset (which would force a racy dev-mode AASA re-fetch and
-          # leave the Universal Link unresolved → openurl falls back to Safari).
+          # Reset associated-domains state before install so the applinks binding isn't wiped later
           xcrun simctl spawn booted swcutil reset || true
           # Disable UIKit animations to reduce Maestro timing flakiness
-          xcrun simctl spawn booted defaults write com.apple.UIKit UIAnimationDragCoefficient 0 || true
+          xcrun simctl spawn booted defaults write com.apple.UIKit UIAnimationDragCoefficient -float 0 || true
 
       - name: Install app on simulator
         run: |
@@ -303,17 +323,13 @@ jobs:
           fi
           echo "Installing: $APP_PATH"
           xcrun simctl install booted "$APP_PATH"
-          # Prime the associated-domains cache for the pay Universal Link domains so
-          # swcd has a verified applinks entry by the time the deeplink flow runs.
+          # Prime the associated-domains cache for the pay Universal Link domains
           for domain in pay.walletconnect.com staging.pay.walletconnect.com dev.pay.walletconnect.com lab.reown.com; do
             xcrun simctl spawn booted swcutil dl -d "$domain" || true
           done
           sleep 3
-          # Dump the FULL association table (not grep-filtered): swcd's per-app/domain
-          # verdict is what tells us whether the Universal Link will resolve, so it must
-          # be visible in CI logs when the deeplink flow flakes.
-          echo "=== swcutil show (associated-domains state after install + priming) ==="
-          xcrun simctl spawn booted swcutil show 2>/dev/null || true
+          echo "=== swcutil show (after install + priming) ==="
+          xcrun simctl spawn booted swcutil show || true
 
       - name: Copy Maestro Pay test flows
         uses: WalletConnect/actions/maestro/pay-tests@52e0ab7755ca993bd829062278654ed12b2d471d
@@ -324,10 +340,8 @@ jobs:
       - name: Run Maestro iOS tests
         id: maestro_ios
         run: |
-          # Snapshot the associated-domains verification state at run start — brackets the
-          # post-install dump above and shows swcd's verdict closer to the deeplink flow.
           echo "=== swcutil show (Maestro run start) ==="
-          xcrun simctl spawn booted swcutil show 2>/dev/null || true
+          xcrun simctl spawn booted swcutil show || true
           maestro test \
             --env APP_ID=com.walletconnect.flutterwallet.internal \
             --env WPAY_CUSTOMER_KEY_SINGLE_NOKYC=${{ secrets.WPAY_CUSTOMER_KEY_SINGLE_NOKYC }} \

--- a/packages/reown_walletkit/example/ios/Runner/Runner.entitlements
+++ b/packages/reown_walletkit/example/ios/Runner/Runner.entitlements
@@ -4,9 +4,7 @@
 <dict>
 	<key>com.apple.developer.associated-domains</key>
 	<array>
-		<string>applinks:lab.web3modal.com</string>
-        <string>applinks:dev.lab.web3modal.com</string>
-		<string>applinks:appkit-lab.reown.com</string>
+		<string>applinks:lab.reown.com</string>
 		<string>applinks:pay.walletconnect.com</string>
 		<string>applinks:staging.pay.walletconnect.com</string>
 		<string>applinks:dev.pay.walletconnect.com</string>


### PR DESCRIPTION
## Summary

Mirrors [reown-com/react-native-examples#524](https://github.com/reown-com/react-native-examples/pull/524) for the Flutter wallet's Pay E2E workflow (`.github/workflows/ci_e2e_pay_tests.yml`). Targets Maestro flakiness in the iOS Universal Link deeplink flow.

- **Bump Maestro actions** `maestro/pay-tests` and `maestro/setup` to the [WalletConnect/actions#92](https://github.com/WalletConnect/actions/pull/92) squash-merge commit on `master` (`52e0ab7`), which isolates pay flows and hardens deeplink handling. Applied to both the Android and iOS jobs.
- **Wait for full iOS sim boot** (`bootstatus -b`) before configuring it, so `swcutil reset` / app install don't race a not-ready device.
- **Move `swcutil reset` to the fresh boot, before app install**, so the install-time `applinks` binding isn't wiped by a later reset (which forced a racy dev-mode AASA re-fetch and dropped the Universal Link to the Safari web fallback).
- **Disable UIKit animations** on the simulator (`UIAnimationDragCoefficient 0`) to cut animation-timing flakiness.
- **Instrument swcd**: prime the pay Universal Link domains and dump the full `swcutil show` table (post-install + Maestro run start) so swcd's per-app/domain verdict is visible in CI logs when the deeplink flow flakes.

### Differences from the RN PR
- Android already disables animations via the `reactivecircus/android-emulator-runner` (`disable-animations: true`), so no change there.
- The RN PR removed a dead `maestro-actions-ref` composite-action input — Flutter uses a plain workflow that pins the SHAs directly, so there's no equivalent to delete.

## Flow

```mermaid
flowchart LR
    A[Boot iOS Simulator] --> B[bootstatus -b: wait full boot]
    B --> C[swcutil reset]
    C --> D[Disable UIKit animations]
    D --> E[Install app]
    E --> F[Prime pay domains + swcutil show]
    F --> G[Copy Pay flows @ 52e0ab7]
    G --> H[Install Maestro @ 52e0ab7]
    H --> I[swcutil show + run Maestro tests]
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)