### PR TITLE
fix(core): upgrade flutter_secure_storage to v10 (#314)

### DIFF
--- a/packages/reown_core/CHANGELOG.md
+++ b/packages/reown_core/CHANGELOG.md
@@ -1,3 +1,14 @@
+## 1.4.0
+
+- Upgraded `flutter_secure_storage` to `^10.0.0`. Existing data stored via the
+  deprecated Android `EncryptedSharedPreferences` (v9.x) is migrated
+  automatically to the new custom-cipher storage on first access; no action is
+  required from integrators.
+- Disabled `resetOnError` so a read/decrypt error no longer wipes the entire
+  shared secure-storage backing store.
+- **Breaking (Android):** `flutter_secure_storage` v10 raises the minimum
+  Android SDK to 23.
+
 ## 1.3.8
 
 - Dependency updates

--- a/packages/reown_core/CHANGELOG.md
+++ b/packages/reown_core/CHANGELOG.md
@@ -4,8 +4,8 @@
   deprecated Android `EncryptedSharedPreferences` (v9.x) is migrated
   automatically to the new custom-cipher storage on first access; no action is
   required from integrators.
-- Disabled `resetOnError` so a read/decrypt error no longer wipes the entire
-  shared secure-storage backing store.
+- Disabled the Android `resetOnError` option so a read/decrypt error no longer
+  wipes the entire shared secure-storage backing store.
 - **Breaking (Android):** `flutter_secure_storage` v10 raises the minimum
   Android SDK to 23.
 

--- a/packages/reown_core/lib/store/secure_store.dart
+++ b/packages/reown_core/lib/store/secure_store.dart
@@ -40,8 +40,19 @@ class SecureStore implements IStore<Map<String, dynamic>> {
 
     try {
       // Try secure storage first
+      // flutter_secure_storage v10 deprecated `encryptedSharedPreferences`
+      // (Jetpack Security is deprecated by Google). Data previously stored via
+      // EncryptedSharedPreferences (v9.x) is migrated automatically to the new
+      // custom-cipher storage on first access, since migrateOnAlgorithmChange
+      // defaults to true. No action is required from integrators.
+      //
+      // resetOnError is disabled because its default (true) wipes the entire
+      // shared "FlutterSecureStorage" backing store on a read/decrypt error -
+      // which would destroy not only our session keys but any other secure
+      // entries the host app stores under the default name. Surfacing the error
+      // lets our fallback storage path handle it without erasing data.
       _secureStorage = const FlutterSecureStorage(
-        aOptions: AndroidOptions(encryptedSharedPreferences: true),
+        aOptions: AndroidOptions(resetOnError: false),
         iOptions: IOSOptions(
           accessibility: KeychainAccessibility.first_unlock_this_device,
         ),

--- a/packages/reown_core/lib/store/secure_store.dart
+++ b/packages/reown_core/lib/store/secure_store.dart
@@ -60,7 +60,14 @@ class SecureStore implements IStore<Map<String, dynamic>> {
 
       await restore();
     } catch (e) {
-      // Fall back to regular storage if secure storage fails
+      // Fall back to regular storage if secure storage fails. This also covers
+      // a failed flutter_secure_storage v10 migration (e.g. OEM keystore
+      // issues): log it so a migration failure is distinguishable from secure
+      // storage simply being unavailable.
+      debugPrint(
+        'SecureStore: secure storage init/restore failed, '
+        'falling back to shared_preferences: $e',
+      );
       _useFallbackStorage = true;
       // Try to restore from fallback storage
       await _restoreFromFallback();

--- a/packages/reown_core/lib/store/secure_store.dart
+++ b/packages/reown_core/lib/store/secure_store.dart
@@ -54,8 +54,8 @@ class SecureStore implements IStore<Map<String, dynamic>> {
     } catch (e) {
       // Fall back to regular storage if secure storage fails
       debugPrint(
-        'SecureStore: secure storage init/restore failed, '
-        'falling back to shared_preferences: $e',
+        'SecureStore: secure storage init/restore failed, falling back to '
+        '${_fallbackStorage.runtimeType}: $e',
       );
       _useFallbackStorage = true;
       // Try to restore from fallback storage

--- a/packages/reown_core/lib/store/secure_store.dart
+++ b/packages/reown_core/lib/store/secure_store.dart
@@ -40,17 +40,9 @@ class SecureStore implements IStore<Map<String, dynamic>> {
 
     try {
       // Try secure storage first
-      // flutter_secure_storage v10 deprecated `encryptedSharedPreferences`
-      // (Jetpack Security is deprecated by Google). Data previously stored via
-      // EncryptedSharedPreferences (v9.x) is migrated automatically to the new
-      // custom-cipher storage on first access, since migrateOnAlgorithmChange
-      // defaults to true. No action is required from integrators.
-      //
-      // resetOnError is disabled because its default (true) wipes the entire
-      // shared "FlutterSecureStorage" backing store on a read/decrypt error -
-      // which would destroy not only our session keys but any other secure
-      // entries the host app stores under the default name. Surfacing the error
-      // lets our fallback storage path handle it without erasing data.
+      // v9.x EncryptedSharedPreferences data is migrated automatically on
+      // first access. resetOnError is disabled to avoid wiping the shared
+      // backing store (and the host app's own entries) on a read error.
       _secureStorage = const FlutterSecureStorage(
         aOptions: AndroidOptions(resetOnError: false),
         iOptions: IOSOptions(
@@ -60,10 +52,7 @@ class SecureStore implements IStore<Map<String, dynamic>> {
 
       await restore();
     } catch (e) {
-      // Fall back to regular storage if secure storage fails. This also covers
-      // a failed flutter_secure_storage v10 migration (e.g. OEM keystore
-      // issues): log it so a migration failure is distinguishable from secure
-      // storage simply being unavailable.
+      // Fall back to regular storage if secure storage fails
       debugPrint(
         'SecureStore: secure storage init/restore failed, '
         'falling back to shared_preferences: $e',

--- a/packages/reown_core/pubspec.yaml
+++ b/packages/reown_core/pubspec.yaml
@@ -1,6 +1,6 @@
 name: reown_core
 description: "Reown is the onchain UX platform that provides toolkits built on top of the WalletConnect Network"
-version: 1.3.8
+version: 1.4.0
 homepage: https://github.com/reown-com/reown_flutter
 repository: https://github.com/reown-com/reown_flutter/tree/master/packages/reown_core
 
@@ -17,7 +17,7 @@ dependencies:
   event: ^3.1.0
   flutter:
     sdk: flutter
-  flutter_secure_storage: ^9.2.4
+  flutter_secure_storage: ^10.0.0
   freezed_annotation: ^3.1.0
   http: ^1.2.2
   json_annotation: ^4.9.0

--- a/packages/reown_yttrium/CHANGELOG.md
+++ b/packages/reown_yttrium/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 0.0.3
+
+- Raised the minimum Android SDK to 23 to align with `reown_core`'s
+  `flutter_secure_storage` v10 dependency.
+
 ## 0.0.2
 
 - LICENSE UPDATE

--- a/packages/reown_yttrium/android/build.gradle
+++ b/packages/reown_yttrium/android/build.gradle
@@ -46,8 +46,6 @@ android {
     }
 
     defaultConfig {
-        // Aligned with reown_core, whose flutter_secure_storage v10 dependency
-        // requires minSdk 23.
         minSdk = 23
     }
 

--- a/packages/reown_yttrium/android/build.gradle
+++ b/packages/reown_yttrium/android/build.gradle
@@ -46,7 +46,9 @@ android {
     }
 
     defaultConfig {
-        minSdk = 21
+        // Aligned with reown_core, whose flutter_secure_storage v10 dependency
+        // requires minSdk 23.
+        minSdk = 23
     }
 
     buildTypes {

--- a/packages/reown_yttrium/pubspec.yaml
+++ b/packages/reown_yttrium/pubspec.yaml
@@ -1,6 +1,6 @@
 name: reown_yttrium
 description: "Reown is the onchain UX platform that provides toolkits built on top of the WalletConnect Network"
-version: 0.0.2
+version: 0.0.3
 homepage: https://github.com/reown-com/reown_flutter
 repository: https://github.com/reown-com/reown_flutter/tree/master/packages/reown_yttrium
 documentation: https://docs.reown.com/walletkit/flutter/early-access/chain-abstraction

--- a/packages/reown_yttrium_utils/CHANGELOG.md
+++ b/packages/reown_yttrium_utils/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 0.0.3
+
+- Raised the minimum Android SDK to 23 to align with `reown_core`'s
+  `flutter_secure_storage` v10 dependency.
+
 ## 0.0.2
 
 - LICENSE UPDATE

--- a/packages/reown_yttrium_utils/android/build.gradle
+++ b/packages/reown_yttrium_utils/android/build.gradle
@@ -47,8 +47,6 @@ android {
     }
 
     defaultConfig {
-        // Aligned with reown_core, whose flutter_secure_storage v10 dependency
-        // requires minSdk 23.
         minSdk = 23
     }
 

--- a/packages/reown_yttrium_utils/android/build.gradle
+++ b/packages/reown_yttrium_utils/android/build.gradle
@@ -47,7 +47,9 @@ android {
     }
 
     defaultConfig {
-        minSdk = 21
+        // Aligned with reown_core, whose flutter_secure_storage v10 dependency
+        // requires minSdk 23.
+        minSdk = 23
     }
 
     buildTypes {

--- a/packages/reown_yttrium_utils/pubspec.yaml
+++ b/packages/reown_yttrium_utils/pubspec.yaml
@@ -1,6 +1,6 @@
 name: reown_yttrium_utils
 description: "Reown is the onchain UX platform that provides toolkits built on top of the WalletConnect Network"
-version: 0.0.2
+version: 0.0.3
 homepage: https://github.com/reown-com/reown_flutter
 repository: https://github.com/reown-com/reown_flutter/tree/master/packages/reown_yttrium_utils
 


### PR DESCRIPTION
## What

Upgrades `flutter_secure_storage` from `^9.2.4` to `^10.0.0` in `reown_core`, resolving the long-standing dependency conflict for apps already on v10 (closes #314).

## Why

`reown_core` was the only package pinning `flutter_secure_storage`, and at `^9` it forced downstream apps onto `dependency_overrides`. v10 is the only place this dependency is declared and `secure_store.dart` is the only consumer.

## Changes

- **Bump to `^10.0.0`** (resolves to 10.3.1).
- **Drop the deprecated `encryptedSharedPreferences: true` Android option.** In v10 it's ignored and Jetpack Security is deprecated by Google. Existing v9.x data stored via `EncryptedSharedPreferences` migrates automatically to the new custom-cipher storage on first access (`migrateOnAlgorithmChange` defaults to `true`).
- **Set `resetOnError: false`.** The v10 default (`true`) wipes the *entire* shared `"FlutterSecureStorage"` backing store on a read/decrypt error — not just our `wc@2:core:*` keys, but any secure entries the host app stores under the default name. Disabling it lets our existing fallback-storage path surface and recover from errors without erasing data.

## Verified on-device (Android, upgrade-in-place)

Installed v9.2.4 build, created a session, then installed the v10 build over the top (no uninstall). Migration ran automatically:

```
Migration complete: 2 items migrated from EncryptedSharedPreferences to custom cipher storage
  - wc@2:core:keychain
  - wc@2:core:0.3//keychain
Migration completed successfully. Now using custom cipher storage.
```

Session remained active after upgrade. iOS uses the Keychain under the same service/accessibility — no migration needed.

## Breaking change

v10 raises the **minimum Android SDK to 23** (consumers below 23 must bump). Both example apps are already ≥24. Dart 3.3 / Flutter 3.19 floors are already satisfied (repo is on Dart 3.8).

## Follow-up (not in this PR): #300

This PR keeps the **default** storage name so existing users migrate cleanly. The proper fix for the namespace-collision issue (#300) is to isolate the SDK's secure storage under a custom `sharedPreferencesName` + key prefix (and iOS account/groupId). That can't be combined here without orphaning existing data — the v10 migration reads from the same store name it writes to, so a name change would strand v9 data. It needs its own one-time data-copy migration and upgrade-in-place testing, tracked separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)