### PR TITLE
ci(walletkit): run Maestro pay E2E tests nightly

### DIFF
--- a/.github/workflows/ci_e2e_pay_tests.yml
+++ b/.github/workflows/ci_e2e_pay_tests.yml
@@ -100,10 +100,10 @@ jobs:
             --split-per-abi
 
       - name: Copy Maestro Pay test flows
-        uses: WalletConnect/actions/maestro/pay-tests@8b950e670018d208a9474725533043e83bf15dbd
+        uses: WalletConnect/actions/maestro/pay-tests@df379c5bcc778ee1fb16072894efaadef9b70826
 
       - name: Install Maestro CLI
-        uses: WalletConnect/actions/maestro/setup@8b950e670018d208a9474725533043e83bf15dbd
+        uses: WalletConnect/actions/maestro/setup@df379c5bcc778ee1fb16072894efaadef9b70826
 
       - name: Setup Android SDK
         uses: android-actions/setup-android@v3
@@ -335,10 +335,10 @@ jobs:
           xcrun simctl spawn booted swcutil show || true
 
       - name: Copy Maestro Pay test flows
-        uses: WalletConnect/actions/maestro/pay-tests@8b950e670018d208a9474725533043e83bf15dbd
+        uses: WalletConnect/actions/maestro/pay-tests@df379c5bcc778ee1fb16072894efaadef9b70826
 
       - name: Install Maestro CLI
-        uses: WalletConnect/actions/maestro/setup@8b950e670018d208a9474725533043e83bf15dbd
+        uses: WalletConnect/actions/maestro/setup@df379c5bcc778ee1fb16072894efaadef9b70826
 
       - name: Run Maestro iOS tests
         id: maestro_ios

--- a/.github/workflows/ci_e2e_pay_tests.yml
+++ b/.github/workflows/ci_e2e_pay_tests.yml
@@ -100,10 +100,10 @@ jobs:
             --split-per-abi
 
       - name: Copy Maestro Pay test flows
-        uses: WalletConnect/actions/maestro/pay-tests@52e0ab7755ca993bd829062278654ed12b2d471d
+        uses: WalletConnect/actions/maestro/pay-tests@3a145abaa0dcf9f609fabe17f6e6722e0db49535
 
       - name: Install Maestro CLI
-        uses: WalletConnect/actions/maestro/setup@52e0ab7755ca993bd829062278654ed12b2d471d
+        uses: WalletConnect/actions/maestro/setup@3a145abaa0dcf9f609fabe17f6e6722e0db49535
 
       - name: Setup Android SDK
         uses: android-actions/setup-android@v3
@@ -335,10 +335,10 @@ jobs:
           xcrun simctl spawn booted swcutil show || true
 
       - name: Copy Maestro Pay test flows
-        uses: WalletConnect/actions/maestro/pay-tests@52e0ab7755ca993bd829062278654ed12b2d471d
+        uses: WalletConnect/actions/maestro/pay-tests@3a145abaa0dcf9f609fabe17f6e6722e0db49535
 
       - name: Install Maestro CLI
-        uses: WalletConnect/actions/maestro/setup@52e0ab7755ca993bd829062278654ed12b2d471d
+        uses: WalletConnect/actions/maestro/setup@3a145abaa0dcf9f609fabe17f6e6722e0db49535
 
       - name: Run Maestro iOS tests
         id: maestro_ios

--- a/.github/workflows/ci_e2e_pay_tests.yml
+++ b/.github/workflows/ci_e2e_pay_tests.yml
@@ -100,10 +100,10 @@ jobs:
             --split-per-abi
 
       - name: Copy Maestro Pay test flows
-        uses: WalletConnect/actions/maestro/pay-tests@df379c5bcc778ee1fb16072894efaadef9b70826
+        uses: WalletConnect/actions/maestro/pay-tests@0730e323043dd2c4989bfc76f11303bb4e2c5774
 
       - name: Install Maestro CLI
-        uses: WalletConnect/actions/maestro/setup@df379c5bcc778ee1fb16072894efaadef9b70826
+        uses: WalletConnect/actions/maestro/setup@0730e323043dd2c4989bfc76f11303bb4e2c5774
 
       - name: Setup Android SDK
         uses: android-actions/setup-android@v3
@@ -335,10 +335,10 @@ jobs:
           xcrun simctl spawn booted swcutil show || true
 
       - name: Copy Maestro Pay test flows
-        uses: WalletConnect/actions/maestro/pay-tests@df379c5bcc778ee1fb16072894efaadef9b70826
+        uses: WalletConnect/actions/maestro/pay-tests@0730e323043dd2c4989bfc76f11303bb4e2c5774
 
       - name: Install Maestro CLI
-        uses: WalletConnect/actions/maestro/setup@df379c5bcc778ee1fb16072894efaadef9b70826
+        uses: WalletConnect/actions/maestro/setup@0730e323043dd2c4989bfc76f11303bb4e2c5774
 
       - name: Run Maestro iOS tests
         id: maestro_ios

--- a/.github/workflows/ci_e2e_pay_tests.yml
+++ b/.github/workflows/ci_e2e_pay_tests.yml
@@ -100,10 +100,10 @@ jobs:
             --split-per-abi
 
       - name: Copy Maestro Pay test flows
-        uses: WalletConnect/actions/maestro/pay-tests@3a145abaa0dcf9f609fabe17f6e6722e0db49535
+        uses: WalletConnect/actions/maestro/pay-tests@8b950e670018d208a9474725533043e83bf15dbd
 
       - name: Install Maestro CLI
-        uses: WalletConnect/actions/maestro/setup@3a145abaa0dcf9f609fabe17f6e6722e0db49535
+        uses: WalletConnect/actions/maestro/setup@8b950e670018d208a9474725533043e83bf15dbd
 
       - name: Setup Android SDK
         uses: android-actions/setup-android@v3
@@ -335,10 +335,10 @@ jobs:
           xcrun simctl spawn booted swcutil show || true
 
       - name: Copy Maestro Pay test flows
-        uses: WalletConnect/actions/maestro/pay-tests@3a145abaa0dcf9f609fabe17f6e6722e0db49535
+        uses: WalletConnect/actions/maestro/pay-tests@8b950e670018d208a9474725533043e83bf15dbd
 
       - name: Install Maestro CLI
-        uses: WalletConnect/actions/maestro/setup@3a145abaa0dcf9f609fabe17f6e6722e0db49535
+        uses: WalletConnect/actions/maestro/setup@8b950e670018d208a9474725533043e83bf15dbd
 
       - name: Run Maestro iOS tests
         id: maestro_ios

--- a/.github/workflows/ci_e2e_pay_tests.yml
+++ b/.github/workflows/ci_e2e_pay_tests.yml
@@ -20,6 +20,9 @@ on:
       - 'packages/reown_walletkit/example/**'
       - 'packages/walletconnect_pay/**'
       - '.github/workflows/ci_e2e_pay_tests.yml'
+  schedule:
+    # Run daily at 06:00 UTC
+    - cron: '0 6 * * *'
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event_name == 'pull_request' && github.event.pull_request.number || github.ref_name }}
@@ -27,7 +30,7 @@ concurrency:
 
 jobs:
   pay-tests-android:
-    if: ${{ github.event_name == 'pull_request' || (github.event_name == 'workflow_dispatch' && github.event.inputs.platform != 'ios') }}
+    if: ${{ github.event_name == 'pull_request' || github.event_name == 'schedule' || (github.event_name == 'workflow_dispatch' && github.event.inputs.platform != 'ios') }}
     runs-on: ubuntu-16core
     timeout-minutes: 45
 
@@ -208,7 +211,7 @@ jobs:
             }
 
   pay-tests-ios:
-    if: ${{ github.event_name == 'pull_request' || (github.event_name == 'workflow_dispatch' && github.event.inputs.platform != 'android') }}
+    if: ${{ github.event_name == 'pull_request' || github.event_name == 'schedule' || (github.event_name == 'workflow_dispatch' && github.event.inputs.platform != 'android') }}
     runs-on: macos-latest-xlarge
     timeout-minutes: 60
 


### PR DESCRIPTION
## Summary

Runs the Maestro Pay E2E tests automatically every 24 hours.

- Adds a `schedule` trigger (`cron: '0 6 * * *'`, daily at 06:00 UTC) to `.github/workflows/ci_e2e_pay_tests.yml`.
- Updates the `if` conditions on both `pay-tests-android` and `pay-tests-ios` so scheduled runs execute both platforms (the jobs previously only ran on `pull_request` / `workflow_dispatch`).

## Notes

- Scheduled workflows only fire from the default branch, so the nightly run starts once this merges into `develop`.
- Existing `if: failure()` Slack notifications will alert on nightly breakages; the trigger field shows `schedule`.
- GitHub Actions billing is flat per-minute (no off-peak pricing), so 06:00 UTC was chosen mainly to avoid peak-hour runner queueing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)