### PR TITLE
ci(walletkit-pay): boot any available iPhone simulator for iOS E2E

### DIFF
--- a/.github/workflows/ci_e2e_pay_tests.yml
+++ b/.github/workflows/ci_e2e_pay_tests.yml
@@ -21,8 +21,8 @@ on:
       - 'packages/walletconnect_pay/**'
       - '.github/workflows/ci_e2e_pay_tests.yml'
   schedule:
-    # Run daily at 06:00 UTC
-    - cron: '0 6 * * *'
+    # Run daily at 07:00 UTC
+    - cron: '0 7 * * *'
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event_name == 'pull_request' && github.event.pull_request.number || github.ref_name }}

--- a/.github/workflows/ci_e2e_pay_tests.yml
+++ b/.github/workflows/ci_e2e_pay_tests.yml
@@ -322,9 +322,20 @@ jobs:
 
       - name: Boot iOS simulator
         run: |
-          xcrun simctl boot "iPhone 16" 2>/dev/null || true
+          # Pick whatever iPhone simulator the runner actually has, so this
+          # doesn't break each time the Xcode/runner image bumps the model.
+          SIMULATOR_UDID=$(xcrun simctl list devices available \
+            | grep -Eo 'iPhone[^(]*\([A-F0-9-]{36}\)' \
+            | grep -Eo '[A-F0-9-]{36}' | head -n 1)
+          if [ -z "$SIMULATOR_UDID" ]; then
+            echo "ERROR: no available iPhone simulator found"
+            xcrun simctl list devices available
+            exit 1
+          fi
+          echo "Using simulator: $SIMULATOR_UDID"
+          xcrun simctl boot "$SIMULATOR_UDID" 2>/dev/null || true
           # Wait for full boot before configuring the simulator
-          xcrun simctl bootstatus "iPhone 16" -b
+          xcrun simctl bootstatus "$SIMULATOR_UDID" -b
           # Reset associated-domains state before install so the applinks binding isn't wiped later
           xcrun simctl spawn booted swcutil reset || true
           # Disable UIKit animations to reduce Maestro timing flakiness

--- a/.github/workflows/ci_e2e_pay_tests.yml
+++ b/.github/workflows/ci_e2e_pay_tests.yml
@@ -325,8 +325,8 @@ jobs:
           # Pick whatever iPhone simulator the runner actually has, so this
           # doesn't break each time the Xcode/runner image bumps the model.
           SIMULATOR_UDID=$(xcrun simctl list devices available \
-            | grep -Eo 'iPhone[^(]*\([A-F0-9-]{36}\)' \
-            | grep -Eo '[A-F0-9-]{36}' | head -n 1)
+            | grep -Eo 'iPhone[^(]*\([A-Fa-f0-9-]{36}\)' \
+            | grep -Eo '[A-Fa-f0-9-]{36}' | head -n 1)
           if [ -z "$SIMULATOR_UDID" ]; then
             echo "ERROR: no available iPhone simulator found"
             xcrun simctl list devices available


### PR DESCRIPTION
# Description

The iOS lane of the Pay E2E workflow hardcoded `iPhone 16` when booting the simulator. On the `macos-26-xlarge` runner (Xcode 26 ships iPhone 17-series simulators), that device no longer exists, so the boot step failed with `Invalid device: iPhone 16` / exit code 148. This change discovers an available iPhone simulator UDID at runtime instead, keeping the workflow green across future runner/Xcode image bumps. All later steps already use the `booted` alias, so only the boot step needed updating.

Resolves # (issue)

## How Has This Been Tested?

Verified the failing job (https://github.com/reown-com/reown_flutter/actions/runs/28153939350/job/83377863987). The simulator-selection command picks the first available iPhone UDID via `xcrun simctl list devices available`; CI will confirm on this PR's run.

## Due Dilligence

* [ ] Breaking change
* [ ] Requires a documentation update