### PR TITLE
chore(samples): update sample wallet/dapp universal links to lab.reown.com

### DIFF
--- a/.github/workflows/release-android-base.yml
+++ b/.github/workflows/release-android-base.yml
@@ -135,7 +135,7 @@ jobs:
           serviceCredentialsFileContent: ${{ secrets.GSA_KEY }}
           groups: flutter-team, javascript-team, kotlin-team, rust-team, unity, wc-testers
           file: ${{ inputs.working-directory }}/build/app/outputs/flutter-apk/app-${{ inputs.flavor }}-release.apk
-          releaseNotes: ${{ inputs.release-notes != '' && inputs.release-notes || format('Branch: {0}', github.ref_name) }}
+          releaseNotes: "${{ inputs.release-notes != '' && inputs.release-notes || format('Branch: {0}', github.ref_name) }}"
 
       - name: Send Slack notification
         if: always() && !cancelled()

--- a/.github/workflows/release-android-base.yml
+++ b/.github/workflows/release-android-base.yml
@@ -56,12 +56,10 @@ jobs:
           platform: 'android'
 
       - name: Setup Firebase
-        # Note: Key file is written to runner.temp which is automatically cleaned up after job
-        run: |
-          echo '${{ secrets.GSA_KEY }}' > ${{ runner.temp }}/gcp_key.json
-          chmod 600 ${{ runner.temp }}/gcp_key.json
-          echo "GOOGLE_APPLICATION_CREDENTIALS=${{ runner.temp }}/gcp_key.json" >> $GITHUB_ENV
-          npm install -g firebase-tools@13.29.0
+        uses: w9jds/setup-firebase@main
+        with:
+          tools-version: 13.0.1
+          gcp_sa_key: ${{ secrets.GSA_KEY }}
 
       - name: Add Secrets file
         working-directory: ${{ inputs.working-directory }}/android

--- a/.github/workflows/release-android-base.yml
+++ b/.github/workflows/release-android-base.yml
@@ -129,19 +129,13 @@ jobs:
 
       - name: Upload to Firebase
         id: firebase-upload
-        working-directory: ${{ inputs.working-directory }}
-        run: |
-          if [ -n "${{ inputs.release-notes }}" ]; then
-            CHANGELOG="${{ inputs.release-notes }}"
-          else
-            CHANGELOG="Branch: ${{ github.ref_name }}"
-          fi
-
-          firebase appdistribution:distribute \
-            build/app/outputs/flutter-apk/app-${{ inputs.flavor }}-release.apk \
-            --app ${{ inputs.firebase-app-id }} \
-            --groups "flutter-team, javascript-team, kotlin-team, rust-team, unity, wc-testers" \
-            --release-notes "$CHANGELOG"
+        uses: wzieba/Firebase-Distribution-Github-Action@v1
+        with:
+          appId: ${{ inputs.firebase-app-id }}
+          serviceCredentialsFileContent: ${{ secrets.GSA_KEY }}
+          groups: flutter-team, javascript-team, kotlin-team, rust-team, unity, wc-testers
+          file: ${{ inputs.working-directory }}/build/app/outputs/flutter-apk/app-${{ inputs.flavor }}-release.apk
+          releaseNotes: ${{ inputs.release-notes != '' && inputs.release-notes || format('Branch: {0}', github.ref_name) }}
 
       - name: Send Slack notification
         if: always() && !cancelled()

--- a/.github/workflows/release-android-base.yml
+++ b/.github/workflows/release-android-base.yml
@@ -129,7 +129,7 @@ jobs:
 
       - name: Upload to Firebase
         id: firebase-upload
-        uses: wzieba/Firebase-Distribution-Github-Action@v1
+        uses: wzieba/Firebase-Distribution-Github-Action@bd494989dd4bec0343f78adee87fe66e48279ad6 # v1.7.1
         with:
           appId: ${{ inputs.firebase-app-id }}
           serviceCredentialsFileContent: ${{ secrets.GSA_KEY }}

--- a/packages/pos_client/README.md
+++ b/packages/pos_client/README.md
@@ -194,7 +194,7 @@ class _PaymentScreenState extends State<PaymentScreen> {
     final metadata = Metadata(
       merchantName: 'DTC Pay',
       description: 'Secure Crypto Payment Terminal',
-      url: 'https://appkit-lab.reown.com',
+      url: 'https://lab.reown.com',
       logoIcon: 'https://avatars.githubusercontent.com/u/179229932',
     );
     posClilent = PosClient(

--- a/packages/pos_client/example/lib/providers/pos_client_provider.dart
+++ b/packages/pos_client/example/lib/providers/pos_client_provider.dart
@@ -7,7 +7,7 @@ final posClilentProvider = Provider<IPosClient>((ref) {
   final metadata = Metadata(
     merchantName: 'DTC Pay',
     description: 'Secure Crypto Payment Terminal',
-    url: 'https://appkit-lab.reown.com',
+    url: 'https://lab.reown.com',
     logoIcon: 'https://avatars.githubusercontent.com/u/179229932',
   );
   return PosClient(

--- a/packages/reown_appkit/example/base/android/app/src/main/AndroidManifest.xml
+++ b/packages/reown_appkit/example/base/android/app/src/main/AndroidManifest.xml
@@ -116,7 +116,7 @@
                 <category android:name="android.intent.category.DEFAULT" />
                 <category android:name="android.intent.category.BROWSABLE" />
                 <data android:scheme="https" />
-                <data android:host="appkit-lab.reown.com" />
+                <data android:host="lab.reown.com" />
                 <data android:pathPattern="/flutter_appkit" />
             </intent-filter>
             <intent-filter android:autoVerify="true">
@@ -124,7 +124,7 @@
                 <category android:name="android.intent.category.DEFAULT" />
                 <category android:name="android.intent.category.BROWSABLE" />
                 <data android:scheme="https" />
-                <data android:host="appkit-lab.reown.com" />
+                <data android:host="lab.reown.com" />
                 <data android:pathPattern="/flutter_appkit_internal" />
             </intent-filter>
             <meta-data android:name="flutter_deeplinking_enabled" android:value="false" />

--- a/packages/reown_appkit/example/base/ios/Podfile.lock
+++ b/packages/reown_appkit/example/base/ios/Podfile.lock
@@ -14,11 +14,11 @@ PODS:
     - Flutter
   - package_info_plus (0.4.5):
     - Flutter
-  - Sentry/HybridSDK (8.58.1)
-  - sentry_flutter (9.17.0):
+  - Sentry/HybridSDK (8.58.3)
+  - sentry_flutter (9.22.0):
     - Flutter
     - FlutterMacOS
-    - Sentry/HybridSDK (= 8.58.1)
+    - Sentry/HybridSDK (= 8.58.3)
   - shared_preferences_foundation (0.0.1):
     - Flutter
     - FlutterMacOS
@@ -81,8 +81,8 @@ SPEC CHECKSUMS:
   Flutter: cabc95a1d2626b1b06e7179b784ebcf0c0cde467
   flutter_secure_storage: 1ed9476fba7e7a782b22888f956cce43e2c62f13
   package_info_plus: af8e2ca6888548050f16fa2f1938db7b5a5df499
-  Sentry: 958d9619ceccf6abb8c4736003fa336dac1a80a7
-  sentry_flutter: b4ad2ac16ea7ad64fd5254c049a5fd5d06510283
+  Sentry: 108fdbb76299c4189af12246bf0308c09c278922
+  sentry_flutter: fbb8a76a5a009ce7ba7bde295ee6b50b11916851
   shared_preferences_foundation: 7036424c3d8ec98dfe75ff1667cb0cd531ec82bb
   sqflite_darwin: 20b2a3a3b70e43edae938624ce550a3cbf66a3d0
   url_launcher_ios: 7a95fa5b60cc718a708b8f2966718e93db0cef1b

--- a/packages/reown_appkit/example/base/ios/Runner/Runner.entitlements
+++ b/packages/reown_appkit/example/base/ios/Runner/Runner.entitlements
@@ -6,7 +6,7 @@
 	<array>
 		<string>applinks:lab.web3modal.com</string>
 		<string>applinks:dev.lab.web3modal.com</string>
-		<string>applinks:appkit-lab.reown.com</string>
+		<string>applinks:lab.reown.com</string>
 	</array>
     <!-- <key>aps-environment</key>
     <string>production</string> -->

--- a/packages/reown_appkit/example/base/lib/main.dart
+++ b/packages/reown_appkit/example/base/lib/main.dart
@@ -200,7 +200,7 @@ class _MyHomePageState extends State<MyHomePage> {
   }
 
   String _universalLink() {
-    Uri link = Uri.parse('https://appkit-lab.reown.com/flutter_appkit');
+    Uri link = Uri.parse('https://lab.reown.com/flutter_appkit');
     if (_flavor.isNotEmpty || kDebugMode) {
       return link.replace(path: '${link.path}_internal').toString();
     }

--- a/packages/reown_appkit/example/modal/android/app/src/main/AndroidManifest.xml
+++ b/packages/reown_appkit/example/modal/android/app/src/main/AndroidManifest.xml
@@ -95,7 +95,7 @@
                 <category android:name="android.intent.category.DEFAULT" />
                 <category android:name="android.intent.category.BROWSABLE" />
                 <data android:scheme="https" />
-                <data android:host="appkit-lab.reown.com" />
+                <data android:host="lab.reown.com" />
                 <data android:pathPattern="/flutter_appkit_modal" />
             </intent-filter>
             <intent-filter android:autoVerify="true">
@@ -103,7 +103,7 @@
                 <category android:name="android.intent.category.DEFAULT" />
                 <category android:name="android.intent.category.BROWSABLE" />
                 <data android:scheme="https" />
-                <data android:host="appkit-lab.reown.com" />
+                <data android:host="lab.reown.com" />
                 <data android:pathPattern="/flutter_appkit_modal_internal" />
             </intent-filter>
             <meta-data android:name="flutter_deeplinking_enabled" android:value="false" />

--- a/packages/reown_appkit/example/modal/ios/Runner/Runner.entitlements
+++ b/packages/reown_appkit/example/modal/ios/Runner/Runner.entitlements
@@ -4,7 +4,7 @@
 <dict>
 	<key>com.apple.developer.associated-domains</key>
 	<array>
-		<string>applinks:appkit-lab.reown.com</string>
+		<string>applinks:lab.reown.com</string>
 	</array>
 </dict>
 </plist>

--- a/packages/reown_appkit/example/modal/lib/home_page.dart
+++ b/packages/reown_appkit/example/modal/lib/home_page.dart
@@ -62,7 +62,7 @@ class _MyHomePageState extends State<MyHomePage> {
   }
 
   String _universalLink() {
-    Uri link = Uri.parse('https://appkit-lab.reown.com/flutter_appkit_modal');
+    Uri link = Uri.parse('https://lab.reown.com/flutter_appkit_modal');
     if (_flavor.isNotEmpty && !kDebugMode) {
       return link.replace(path: '${link.path}_internal').toString();
     }

--- a/packages/reown_walletkit/example/android/app/src/main/AndroidManifest.xml
+++ b/packages/reown_walletkit/example/android/app/src/main/AndroidManifest.xml
@@ -77,7 +77,7 @@
                 <category android:name="android.intent.category.BROWSABLE" />
 
                 <data android:scheme="https" />
-                <data android:host="appkit-lab.reown.com" />
+                <data android:host="lab.reown.com" />
                 <data android:pathPattern="/flutter_walletkit" />
             </intent-filter>
             <intent-filter android:autoVerify="true">
@@ -87,7 +87,7 @@
                 <category android:name="android.intent.category.BROWSABLE" />
 
                 <data android:scheme="https" />
-                <data android:host="appkit-lab.reown.com" />
+                <data android:host="lab.reown.com" />
                 <data android:pathPattern="/flutter_walletkit_internal" />
             </intent-filter>
             <!-- WalletConnect Pay App Links -->

--- a/packages/reown_walletkit/example/lib/dependencies/walletkit_service.dart
+++ b/packages/reown_walletkit/example/lib/dependencies/walletkit_service.dart
@@ -790,7 +790,7 @@ class WalletKitService implements IWalletKitService {
   }
 
   String _universalLink() {
-    Uri link = Uri.parse('https://appkit-lab.reown.com/flutter_walletkit');
+    Uri link = Uri.parse('https://lab.reown.com/flutter_walletkit');
     if (_flavor.isNotEmpty || kDebugMode) {
       return link.replace(path: '${link.path}_internal').toString();
     }


### PR DESCRIPTION
# Description

Updates the universal/app links and metadata URLs across all sample apps from the old `appkit-lab.reown.com` host to `lab.reown.com`. This covers the WalletKit sample (Android manifest, iOS entitlements, and the wallet metadata `url`/`redirect.universal` via `_universalLink()`), the AppKit base and modal samples (Android manifests, iOS entitlements, Dart link builders), and the `pos_client` sample/README metadata. iOS associated domains and Dart link builders now resolve to `lab.reown.com`, matching the existing `apple-app-site-association` entries already published there.

Resolves # (issue)

## How Has This Been Tested?

Verified via `grep` that no `appkit-lab` references remain in `packages/`, and cross-checked the new host against `lab.reown.com`'s published AASA and `assetlinks.json`: iOS appIDs/paths match for all three Flutter apps (team `W5R8AG9K22`), and Android package names match for walletkit and appkit base. Note: the appkit modal Android package (`com.web3modal.flutterExample`) is not yet present in the server-side `assetlinks.json`, so its Android App Links will remain unverified until those signing fingerprints are added on `lab.reown.com`.

## Due Dilligence

* [ ] Breaking change
* [ ] Requires a documentation update