### PR TITLE
ci(e2e-pay): skip E2E on draft PRs; add balance-check job; keep off-KPI runs out of metrics

### DIFF
--- a/.github/workflows/ci_e2e_pay_tests.yml
+++ b/.github/workflows/ci_e2e_pay_tests.yml
@@ -20,6 +20,13 @@ on:
           - ios
         default: both
   pull_request:
+    # Explicit types = GitHub defaults + ready_for_review, so E2E fires
+    # immediately when a draft is marked ready (not just on the next push).
+    types:
+      - opened
+      - synchronize
+      - reopened
+      - ready_for_review
     paths:
       - 'packages/reown_walletkit/example/**'
       - 'packages/walletconnect_pay/**'

--- a/.github/workflows/ci_e2e_pay_tests.yml
+++ b/.github/workflows/ci_e2e_pay_tests.yml
@@ -1,9 +1,5 @@
 name: E2E Pay Tests
-# run-name shows the platform under test (both/android/ios). The trailing
-# "(skip-metrics)" marker is consumed by the E2E KPI metrics job
-# (WalletConnect/actions) to drop a run from the dashboard; we stamp it on runs that
-# shouldn't count: draft PRs, and manual (workflow_dispatch) runs off the default
-# branch ('develop'). Don't change/remove the marker.
+# "(skip-metrics)" tells the E2E KPI job (WalletConnect/actions) to drop this run.
 run-name: "E2E Pay Tests (${{ github.event.inputs.platform || 'both' }})${{ ((github.event_name == 'pull_request' && github.event.pull_request.draft) || (github.event_name == 'workflow_dispatch' && github.ref_name != 'develop')) && ' (skip-metrics)' || '' }}"
 
 permissions:
@@ -22,8 +18,6 @@ on:
           - ios
         default: both
   pull_request:
-    # Explicit types = GitHub defaults + ready_for_review, so E2E fires
-    # immediately when a draft is marked ready (not just on the next push).
     types:
       - opened
       - synchronize
@@ -43,16 +37,12 @@ concurrency:
 
 jobs:
   check-balance:
-    # Skip on draft PRs (matches the test jobs) so a draft run has all jobs
-    # skipped -> run conclusion "skipped", never counted toward KPIs.
     if: github.event_name != 'pull_request' || github.event.pull_request.draft == false
     uses: ./.github/workflows/e2e_balance_check.yml
     secrets: inherit
 
   pay-tests-android:
     needs: check-balance
-    # always(): balance alert should not block tests. Skip draft PRs (still
-    # runnable manually via workflow_dispatch).
     if: ${{ always() && ((github.event_name == 'pull_request' && github.event.pull_request.draft == false) || github.event_name == 'schedule' || (github.event_name == 'workflow_dispatch' && github.event.inputs.platform != 'ios')) }}
     runs-on: ubuntu-16core
     timeout-minutes: 45
@@ -250,8 +240,6 @@ jobs:
 
   pay-tests-ios:
     needs: check-balance
-    # always(): balance alert should not block tests. Skip draft PRs (still
-    # runnable manually via workflow_dispatch).
     if: ${{ always() && ((github.event_name == 'pull_request' && github.event.pull_request.draft == false) || github.event_name == 'schedule' || (github.event_name == 'workflow_dispatch' && github.event.inputs.platform != 'android')) }}
     runs-on: macos-latest-xlarge
     timeout-minutes: 60

--- a/.github/workflows/ci_e2e_pay_tests.yml
+++ b/.github/workflows/ci_e2e_pay_tests.yml
@@ -1,10 +1,10 @@
 name: E2E Pay Tests
-# "(skip-metrics)" in the run-name is consumed by the E2E KPI metrics job
-# (WalletConnect/actions) to drop a run from the dashboard. We stamp it on runs that
+# run-name shows the platform under test (both/android/ios). The trailing
+# "(skip-metrics)" marker is consumed by the E2E KPI metrics job
+# (WalletConnect/actions) to drop a run from the dashboard; we stamp it on runs that
 # shouldn't count: draft PRs, and manual (workflow_dispatch) runs off the default
-# branch ('develop'). Every other run leaves run-name empty and keeps GitHub's
-# default title. Don't change/remove the marker.
-run-name: ${{ ((github.event_name == 'pull_request' && github.event.pull_request.draft) || (github.event_name == 'workflow_dispatch' && github.ref_name != 'develop')) && format('{0} (skip-metrics)', github.event.pull_request.title || github.ref_name) || '' }}
+# branch ('develop'). Don't change/remove the marker.
+run-name: "E2E Pay Tests (${{ github.event.inputs.platform || 'both' }})${{ ((github.event_name == 'pull_request' && github.event.pull_request.draft) || (github.event_name == 'workflow_dispatch' && github.ref_name != 'develop')) && ' (skip-metrics)' || '' }}"
 
 permissions:
   contents: read

--- a/.github/workflows/ci_e2e_pay_tests.yml
+++ b/.github/workflows/ci_e2e_pay_tests.yml
@@ -1,8 +1,10 @@
 name: E2E Pay Tests
-# The " (Draft)" suffix is consumed by the E2E KPI metrics job (WalletConnect/actions)
-# to exclude draft-PR runs from the dashboard. Draft runs get a custom title; every
-# other run falls back to GitHub's default title (empty run-name). Don't change/remove it.
-run-name: ${{ github.event.pull_request.draft && format('{0} (Draft)', github.event.pull_request.title) || '' }}
+# "(skip-metrics)" in the run-name is consumed by the E2E KPI metrics job
+# (WalletConnect/actions) to drop a run from the dashboard. We stamp it on runs that
+# shouldn't count: draft PRs, and manual (workflow_dispatch) runs off the default
+# branch ('develop'). Every other run leaves run-name empty and keeps GitHub's
+# default title. Don't change/remove the marker.
+run-name: ${{ ((github.event_name == 'pull_request' && github.event.pull_request.draft) || (github.event_name == 'workflow_dispatch' && github.ref_name != 'develop')) && format('{0} (skip-metrics)', github.event.pull_request.title || github.ref_name) || '' }}
 
 permissions:
   contents: read

--- a/.github/workflows/ci_e2e_pay_tests.yml
+++ b/.github/workflows/ci_e2e_pay_tests.yml
@@ -1,4 +1,8 @@
 name: E2E Pay Tests
+# The " (Draft)" suffix is consumed by the E2E KPI metrics job (WalletConnect/actions)
+# to exclude draft-PR runs from the dashboard. Draft runs get a custom title; every
+# other run falls back to GitHub's default title (empty run-name). Don't change/remove it.
+run-name: ${{ github.event.pull_request.draft && format('{0} (Draft)', github.event.pull_request.title) || '' }}
 
 permissions:
   contents: read
@@ -30,7 +34,8 @@ concurrency:
 
 jobs:
   pay-tests-android:
-    if: ${{ github.event_name == 'pull_request' || github.event_name == 'schedule' || (github.event_name == 'workflow_dispatch' && github.event.inputs.platform != 'ios') }}
+    # Skip draft PRs (still runnable manually via workflow_dispatch).
+    if: ${{ (github.event_name == 'pull_request' && github.event.pull_request.draft == false) || github.event_name == 'schedule' || (github.event_name == 'workflow_dispatch' && github.event.inputs.platform != 'ios') }}
     runs-on: ubuntu-16core
     timeout-minutes: 45
 
@@ -226,7 +231,8 @@ jobs:
             }
 
   pay-tests-ios:
-    if: ${{ github.event_name == 'pull_request' || github.event_name == 'schedule' || (github.event_name == 'workflow_dispatch' && github.event.inputs.platform != 'android') }}
+    # Skip draft PRs (still runnable manually via workflow_dispatch).
+    if: ${{ (github.event_name == 'pull_request' && github.event.pull_request.draft == false) || github.event_name == 'schedule' || (github.event_name == 'workflow_dispatch' && github.event.inputs.platform != 'android') }}
     runs-on: macos-latest-xlarge
     timeout-minutes: 60
 

--- a/.github/workflows/ci_e2e_pay_tests.yml
+++ b/.github/workflows/ci_e2e_pay_tests.yml
@@ -42,9 +42,18 @@ concurrency:
   cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 jobs:
+  check-balance:
+    # Skip on draft PRs (matches the test jobs) so a draft run has all jobs
+    # skipped -> run conclusion "skipped", never counted toward KPIs.
+    if: github.event_name != 'pull_request' || github.event.pull_request.draft == false
+    uses: ./.github/workflows/e2e_balance_check.yml
+    secrets: inherit
+
   pay-tests-android:
-    # Skip draft PRs (still runnable manually via workflow_dispatch).
-    if: ${{ (github.event_name == 'pull_request' && github.event.pull_request.draft == false) || github.event_name == 'schedule' || (github.event_name == 'workflow_dispatch' && github.event.inputs.platform != 'ios') }}
+    needs: check-balance
+    # always(): balance alert should not block tests. Skip draft PRs (still
+    # runnable manually via workflow_dispatch).
+    if: ${{ always() && ((github.event_name == 'pull_request' && github.event.pull_request.draft == false) || github.event_name == 'schedule' || (github.event_name == 'workflow_dispatch' && github.event.inputs.platform != 'ios')) }}
     runs-on: ubuntu-16core
     timeout-minutes: 45
 
@@ -240,8 +249,10 @@ jobs:
             }
 
   pay-tests-ios:
-    # Skip draft PRs (still runnable manually via workflow_dispatch).
-    if: ${{ (github.event_name == 'pull_request' && github.event.pull_request.draft == false) || github.event_name == 'schedule' || (github.event_name == 'workflow_dispatch' && github.event.inputs.platform != 'android') }}
+    needs: check-balance
+    # always(): balance alert should not block tests. Skip draft PRs (still
+    # runnable manually via workflow_dispatch).
+    if: ${{ always() && ((github.event_name == 'pull_request' && github.event.pull_request.draft == false) || github.event_name == 'schedule' || (github.event_name == 'workflow_dispatch' && github.event.inputs.platform != 'android')) }}
     runs-on: macos-latest-xlarge
     timeout-minutes: 60
 

--- a/.github/workflows/e2e_balance_check.yml
+++ b/.github/workflows/e2e_balance_check.yml
@@ -7,9 +7,10 @@ name: E2E Wallet Balance Check
 
 on:
   workflow_dispatch: {}
-  schedule:
-    # Run daily at 07:00 UTC
-    - cron: '0 7 * * *'
+  # Called as a gating job by ci_e2e_pay_tests.yml (which runs on PRs + the
+  # daily 07:00 UTC schedule), mirroring reown-kotlin / reown-swift. No standalone
+  # schedule here — it would double-fire alongside the pay-tests cron.
+  workflow_call: {}
 
 permissions:
   contents: read

--- a/.github/workflows/e2e_balance_check.yml
+++ b/.github/workflows/e2e_balance_check.yml
@@ -7,9 +7,7 @@ name: E2E Wallet Balance Check
 
 on:
   workflow_dispatch: {}
-  # Called as a gating job by ci_e2e_pay_tests.yml (which runs on PRs + the
-  # daily 07:00 UTC schedule), mirroring reown-kotlin / reown-swift. No standalone
-  # schedule here — it would double-fire alongside the pay-tests cron.
+  # Run as a job by ci_e2e_pay_tests.yml (mirrors kotlin/swift); no standalone schedule.
   workflow_call: {}
 
 permissions:


### PR DESCRIPTION
## Why

Draft PRs run the full Maestro Pay E2E (android + ios) on every push — expensive WIP CI. This repo is **PR-trigger only** in the E2E KPI dashboard (no branch filter), so draft-PR runs **and** ad-hoc manual (`workflow_dispatch`) runs on feature branches land in **pass / flake / p95**. A hung E2E job on a draft PR recently pushed a platform’s **P95 PR feedback to 62m** vs the usual ~30m.

## Changes

1. **Skip E2E on draft PRs** — folded into each job’s event guard; schedule / `workflow_dispatch` untouched.
2. **Trigger on `ready_for_review`** so E2E fires the moment a draft is marked ready.
3. **`(skip-metrics)` marker in `run-name`** — stamped on runs that shouldn’t count: draft PRs, and manual runs off the default branch (`develop`). The metrics job (WalletConnect/actions) drops any run whose title carries it. `run-name` also now surfaces the **platform** under test — `E2E Pay Tests (both|android|ios)`.
4. **Run the balance check as a gating job, like kotlin/swift.** flutter’s `e2e_balance_check.yml` was a standalone daily monitor; the other platforms run it as a `check-balance` job inside the pay-tests workflow. This PR mirrors that:
   - `e2e_balance_check.yml`: add `workflow_call`, drop the standalone `schedule` (it would double-fire with the pay-tests `0 7 * * *` cron, which now runs the check as a job — daily coverage is preserved).
   - `ci_e2e_pay_tests.yml`: add a draft-guarded `check-balance` job; both test jobs `needs: check-balance` + `always()` so the balance alert never blocks tests. On a draft PR **all** jobs skip → run conclusion `skipped` → excluded from KPIs even independent of the marker.

## Dependency

Metrics-side filter that consumes the marker: **WalletConnect/actions#107** (draft). Until it merges, this PR still stops draft PRs from running E2E; the marker is inert.

🤖 Generated with [Claude Code](https://claude.com/claude-code)