### PR TITLE
chore(release): appkit 1.8.4, walletkit 1.4.1, walletconnect_pay 1.0.1

### DIFF
--- a/packages/reown_appkit/CHANGELOG.md
+++ b/packages/reown_appkit/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 - Fixed wallet install detection
 - Fixed modal close guard
-- Bumped `reown_core` to 1.4.0 — `flutter_secure_storage` v10 (existing data
+- Updated `reown_core` to 1.4.0 — `flutter_secure_storage` v10 (existing data
   auto-migrates; raises the minimum Android SDK to 23)
 
 ## 1.8.3

--- a/packages/reown_appkit/CHANGELOG.md
+++ b/packages/reown_appkit/CHANGELOG.md
@@ -1,3 +1,10 @@
+## 1.8.4
+
+- Fixed wallet install detection
+- Fixed modal close guard
+- Bumped `reown_core` to 1.4.0 — `flutter_secure_storage` v10 (existing data
+  auto-migrates; raises the minimum Android SDK to 23)
+
 ## 1.8.3
 
 - Enabled Coinbase exchange in Deposit With Exchange flow

--- a/packages/reown_appkit/pubspec.yaml
+++ b/packages/reown_appkit/pubspec.yaml
@@ -1,6 +1,6 @@
 name: reown_appkit
 description: "Reown is the onchain UX platform that provides toolkits built on top of the WalletConnect Network"
-version: 1.8.3
+version: 1.8.4
 homepage: https://github.com/reown-com/reown_flutter
 repository: https://github.com/reown-com/reown_flutter/tree/master/packages/reown_appkit
 documentation: https://docs.reown.com/appkit/flutter/core/installation

--- a/packages/reown_walletkit/CHANGELOG.md
+++ b/packages/reown_walletkit/CHANGELOG.md
@@ -1,7 +1,7 @@
 ## 1.4.1
 
 - Dependency updates (`walletconnect_pay`, `reown_yttrium`)
-- Bumped `reown_core` to 1.4.0 — `flutter_secure_storage` v10 (existing data
+- Updated `reown_core` to 1.4.0 — `flutter_secure_storage` v10 (existing data
   auto-migrates; raises the minimum Android SDK to 23)
 
 ## 1.4.0

--- a/packages/reown_walletkit/CHANGELOG.md
+++ b/packages/reown_walletkit/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 1.4.1
+
+- Dependency updates (`walletconnect_pay`, `reown_yttrium`)
+- Bumped `reown_core` to 1.4.0 — `flutter_secure_storage` v10 (existing data
+  auto-migrates; raises the minimum Android SDK to 23)
+
 ## 1.4.0
 
 - Support for WalletConnectPay

--- a/packages/reown_walletkit/pubspec.yaml
+++ b/packages/reown_walletkit/pubspec.yaml
@@ -1,6 +1,6 @@
 name: reown_walletkit
 description: "Reown is the onchain UX platform that provides toolkits built on top of the WalletConnect Network"
-version: 1.4.0
+version: 1.4.1
 homepage: https://github.com/reown-com/reown_flutter
 repository: https://github.com/reown-com/reown_flutter/tree/master/packages/reown_walletkit
 documentation: https://docs.reown.com/walletkit/flutter/installation

--- a/packages/reown_yttrium/CHANGELOG.md
+++ b/packages/reown_yttrium/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## 0.0.3
 
+- Bumped Yttrium to 0.10.58 (Android) / 0.10.57 (iOS).
 - Raised the minimum Android SDK to 23 to align with `reown_core`'s
   `flutter_secure_storage` v10 dependency.
 

--- a/packages/reown_yttrium_utils/CHANGELOG.md
+++ b/packages/reown_yttrium_utils/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## 0.0.3
 
+- Bumped Yttrium Utils to 0.10.58 (Android) / 0.10.57 (iOS).
 - Raised the minimum Android SDK to 23 to align with `reown_core`'s
   `flutter_secure_storage` v10 dependency.
 

--- a/packages/walletconnect_pay/CHANGELOG.md
+++ b/packages/walletconnect_pay/CHANGELOG.md
@@ -1,3 +1,10 @@
+## 1.0.1
+
+- Added WebView-based payment data collection
+- Added per-option payment data collection
+- Fixed WalletConnect Pay metadata handling
+- Yttrium updates
+
 ## 1.0.0
 
 - Official Flutter plugin for WalletConnect Pay

--- a/packages/walletconnect_pay/pubspec.yaml
+++ b/packages/walletconnect_pay/pubspec.yaml
@@ -1,6 +1,6 @@
 name: walletconnect_pay
 description: "Official Flutter plugin for WalletConnect Pay - enabling wallets to accept crypto and stablecoin payments across multiple blockchain networks."
-version: 1.0.0
+version: 1.0.1
 homepage: https://github.com/reown-com/reown_flutter
 repository: https://github.com/reown-com/reown_flutter/tree/develop/packages/walletconnect_pay
 

--- a/packages/walletconnect_pay/pubspec.yaml
+++ b/packages/walletconnect_pay/pubspec.yaml
@@ -2,7 +2,7 @@ name: walletconnect_pay
 description: "Official Flutter plugin for WalletConnect Pay - enabling wallets to accept crypto and stablecoin payments across multiple blockchain networks."
 version: 1.0.1
 homepage: https://github.com/reown-com/reown_flutter
-repository: https://github.com/reown-com/reown_flutter/tree/develop/packages/walletconnect_pay
+repository: https://github.com/reown-com/reown_flutter/tree/master/packages/walletconnect_pay
 
 environment:
   sdk: ">=3.8.0 <4.0.0"


### PR DESCRIPTION
## Pre-release version bumps

Manual pre-release step (per the [Flutter Runbook](https://app.notion.com/p/walletconnect/Flutter-Runbook-3033a661771e8069b8e7df43d77b13e3)): bump versions + update CHANGELOGs, then trigger `publish-packages.yml`.

### Bumped (real post-publish changes)
| Package | Version | Notes |
|---|---|---|
| `reown_appkit` | 1.8.3 → **1.8.4** | Wallet install detection + modal close guard fixes (#386) |
| `reown_walletkit` | 1.4.0 → **1.4.1** | Consume updated `walletconnect_pay` / `reown_yttrium` |
| `walletconnect_pay` | 1.0.0 → **1.0.1** | WebView + per-option payment data collection, metadata fix, Yttrium updates |

### Not bumped — publish staged version as-is
These already sit at an **unpublished** version in `pubspec.yaml`; bumping would orphan the staged version.

| Package | pubspec | pub.dev | Action |
|---|---|---|---|
| `reown_core` | 1.4.0 | 1.3.8 | Publish staged **1.4.0** (`flutter_secure_storage` v10 / min Android SDK 23) |
| `reown_yttrium` | 0.0.3 | 0.0.2 | Publish staged **0.0.3** |
| `reown_yttrium_utils` | 0.0.3 | — | Publish staged **0.0.3** (first publish) |

`reown_sign` (1.3.9) is **not** released — no code changes, and its `reown_core: ^1.3.8` caret already covers 1.4.0. The publish workflow auto-updates downstream constraints in its own PR.

### Notes
- The `flutter_secure_storage` v10 migration / **min Android SDK 23** change is documented in `reown_core`'s 1.4.0 entry and mirrored into the `appkit`/`walletkit` changelogs so integrators see it.
- ⚠️ Merge order: the Yttrium native-wrapper bump (separate `update-yttrium-wrappers` branch) should land on `develop` first; its native version bumps fold into the existing `reown_yttrium`/`reown_yttrium_utils` 0.0.3 entries and `walletconnect_pay`'s "Yttrium updates" line. Watch for a CHANGELOG conflict in `walletconnect_pay`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)