### PR TITLE
chore(walletkit): re-add appkit-lab.reown.com universal link (android + ios)

### DIFF
--- a/packages/reown_walletkit/example/android/app/src/main/AndroidManifest.xml
+++ b/packages/reown_walletkit/example/android/app/src/main/AndroidManifest.xml
@@ -90,6 +90,26 @@
                 <data android:host="lab.reown.com" />
                 <data android:pathPattern="/flutter_walletkit_internal" />
             </intent-filter>
+            <intent-filter android:autoVerify="true">
+                <action android:name="android.intent.action.VIEW" />
+
+                <category android:name="android.intent.category.DEFAULT" />
+                <category android:name="android.intent.category.BROWSABLE" />
+
+                <data android:scheme="https" />
+                <data android:host="appkit-lab.reown.com" />
+                <data android:pathPattern="/flutter_walletkit" />
+            </intent-filter>
+            <intent-filter android:autoVerify="true">
+                <action android:name="android.intent.action.VIEW" />
+
+                <category android:name="android.intent.category.DEFAULT" />
+                <category android:name="android.intent.category.BROWSABLE" />
+
+                <data android:scheme="https" />
+                <data android:host="appkit-lab.reown.com" />
+                <data android:pathPattern="/flutter_walletkit_internal" />
+            </intent-filter>
             <!-- WalletConnect Pay App Links -->
             <intent-filter android:autoVerify="true">
                 <action android:name="android.intent.action.VIEW" />

--- a/packages/reown_walletkit/example/ios/Runner/Runner.entitlements
+++ b/packages/reown_walletkit/example/ios/Runner/Runner.entitlements
@@ -5,6 +5,7 @@
 	<key>com.apple.developer.associated-domains</key>
 	<array>
 		<string>applinks:lab.reown.com</string>
+		<string>applinks:appkit-lab.reown.com</string>
 		<string>applinks:pay.walletconnect.com</string>
 		<string>applinks:staging.pay.walletconnect.com</string>
 		<string>applinks:dev.pay.walletconnect.com</string>


### PR DESCRIPTION
# Description

The sample apps' universal-link host was switched from `appkit-lab.reown.com` to `lab.reown.com` in #390, which was a hard swap that stopped the old host from routing into the app. This re-adds `appkit-lab.reown.com` as an **incoming** universal-link route alongside `lab.reown.com` in the WalletKit example, so both hosts open the wallet during the transition period. Android gets two additional `autoVerify` intent-filters (`/flutter_walletkit` and `/flutter_walletkit_internal`) and iOS gets `applinks:appkit-lab.reown.com` added to its associated-domains entitlement. The outbound advertised link (`_universalLink()`) intentionally stays `lab.reown.com`.

Resolves # (issue)

## How Has This Been Tested?

Verified both hosts route to the wallet on Android via `adb shell am start -a android.intent.action.VIEW -d "https://<host>/flutter_walletkit_internal"` for both `appkit-lab.reown.com` and `lab.reown.com`. Note: silent verified-link opening also requires each domain to serve its `.well-known/assetlinks.json` (Android) and `apple-app-site-association` (iOS), which are hosted outside this repo.

## Due Dilligence

* [ ] Breaking change
* [ ] Requires a documentation update