### PR TITLE
ci(e2e-pay): point maestro actions to latest merged SHA

### DIFF
--- a/.github/workflows/ci_e2e_pay_tests.yml
+++ b/.github/workflows/ci_e2e_pay_tests.yml
@@ -113,10 +113,10 @@ jobs:
             --split-per-abi
 
       - name: Copy Maestro Pay test flows
-        uses: WalletConnect/actions/maestro/pay-tests@3fd66ca1de3848a089d8e3c628e6f54bfcfd999f
+        uses: WalletConnect/actions/maestro/pay-tests@d385e7a80fb4a3d378ee685021f3f7e24ccdf291
 
       - name: Install Maestro CLI
-        uses: WalletConnect/actions/maestro/setup@0730e323043dd2c4989bfc76f11303bb4e2c5774
+        uses: WalletConnect/actions/maestro/setup@d385e7a80fb4a3d378ee685021f3f7e24ccdf291
 
       - name: Setup Android SDK
         uses: android-actions/setup-android@v3
@@ -160,7 +160,7 @@ jobs:
       - name: Reset USDT Permit2 allowance (Polygon)
         if: always()
         continue-on-error: true
-        uses: WalletConnect/actions/maestro/permit2-reset@3fd66ca1de3848a089d8e3c628e6f54bfcfd999f
+        uses: WalletConnect/actions/maestro/permit2-reset@d385e7a80fb4a3d378ee685021f3f7e24ccdf291
         with:
           chain-id: eip155:137
           rpc-url: https://polygon-bor-rpc.publicnode.com
@@ -375,10 +375,10 @@ jobs:
           xcrun simctl spawn booted swcutil show || true
 
       - name: Copy Maestro Pay test flows
-        uses: WalletConnect/actions/maestro/pay-tests@3fd66ca1de3848a089d8e3c628e6f54bfcfd999f
+        uses: WalletConnect/actions/maestro/pay-tests@d385e7a80fb4a3d378ee685021f3f7e24ccdf291
 
       - name: Install Maestro CLI
-        uses: WalletConnect/actions/maestro/setup@0730e323043dd2c4989bfc76f11303bb4e2c5774
+        uses: WalletConnect/actions/maestro/setup@d385e7a80fb4a3d378ee685021f3f7e24ccdf291
 
       - name: Run Maestro iOS tests
         id: maestro_ios
@@ -405,7 +405,7 @@ jobs:
       - name: Reset USDT Permit2 allowance (Polygon)
         if: always()
         continue-on-error: true
-        uses: WalletConnect/actions/maestro/permit2-reset@3fd66ca1de3848a089d8e3c628e6f54bfcfd999f
+        uses: WalletConnect/actions/maestro/permit2-reset@d385e7a80fb4a3d378ee685021f3f7e24ccdf291
         with:
           chain-id: eip155:137
           rpc-url: https://polygon-bor-rpc.publicnode.com

--- a/scripts/setup-maestro-pay-tests.sh
+++ b/scripts/setup-maestro-pay-tests.sh
@@ -5,7 +5,7 @@
 
 set -euo pipefail
 
-REF="${1:-3fd66ca1de3848a089d8e3c628e6f54bfcfd999f}"
+REF="${1:-d385e7a80fb4a3d378ee685021f3f7e24ccdf291}"
 REPO="WalletConnect/actions"
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 ROOT_DIR="$(dirname "$SCRIPT_DIR")"


### PR DESCRIPTION
## Summary
Points the WalletConnect Pay Maestro E2E actions to the latest merged SHA `d385e7a80fb4a3d378ee685021f3f7e24ccdf291` from [WalletConnect/actions](https://github.com/WalletConnect/actions).

## Changes
- `.github/workflows/ci_e2e_pay_tests.yml` — bump `maestro/pay-tests`, `maestro/setup`, and `maestro/permit2-reset` to the new SHA (Android + iOS lanes).
- `scripts/setup-maestro-pay-tests.sh` — bump the default pinned `REF`.

Left `claude/auto-review@master` untouched (not a maestro action).

🤖 Generated with [Claude Code](https://claude.com/claude-code)