### PR TITLE
ci(e2e-pay): drop universal-link (deeplink) support from wallet E2E

### DIFF
--- a/.github/workflows/ci_e2e_pay_tests.yml
+++ b/.github/workflows/ci_e2e_pay_tests.yml
@@ -113,10 +113,10 @@ jobs:
             --split-per-abi
 
       - name: Copy Maestro Pay test flows
-        uses: WalletConnect/actions/maestro/pay-tests@ddc7c0f9acd8b1576e9a78f0ef67f4b8fbb36db2
+        uses: WalletConnect/actions/maestro/pay-tests@28181b5f133836380d2d9bb8ff06af5c3234fb9d
 
       - name: Install Maestro CLI
-        uses: WalletConnect/actions/maestro/setup@ddc7c0f9acd8b1576e9a78f0ef67f4b8fbb36db2
+        uses: WalletConnect/actions/maestro/setup@28181b5f133836380d2d9bb8ff06af5c3234fb9d
 
       - name: Setup Android SDK
         uses: android-actions/setup-android@v3
@@ -160,7 +160,7 @@ jobs:
       - name: Reset USDT Permit2 allowance (Polygon)
         if: always()
         continue-on-error: true
-        uses: WalletConnect/actions/maestro/permit2-reset@ddc7c0f9acd8b1576e9a78f0ef67f4b8fbb36db2
+        uses: WalletConnect/actions/maestro/permit2-reset@28181b5f133836380d2d9bb8ff06af5c3234fb9d
         with:
           chain-id: eip155:137
           rpc-url: https://polygon-bor-rpc.publicnode.com
@@ -266,15 +266,12 @@ jobs:
         run: pod repo update --silent
 
       # Two-step iOS simulator build: let Flutter emit Dart kernel +
-      # Generated.xcconfig, then drive xcodebuild ourselves.
-      # `flutter build ios --simulator` passes CODE_SIGNING_ALLOWED=NO,
-      # which strips entitlements and breaks Universal Links on the CI
-      # simulator (deep-link flow falls back to Safari). We also
-      # override DEVELOPMENT_TEAM + CODE_SIGN_STYLE: the project only
-      # sets DEVELOPMENT_TEAM for sdk=iphoneos*, so a plain simulator
-      # build would sign with an empty team prefix, and iOS rejects
-      # the app as an AASA handler because W5R8AG9K22.<bundle> from
-      # the AASA no longer matches the app's application-identifier.
+      # Generated.xcconfig, then drive xcodebuild ourselves. The custom
+      # xcodebuild step exists only to pin ARCHS=x86_64 for the
+      # mobile_scanner/MLKit simulator slice (see the build step below) —
+      # `flutter build ios --simulator` can't override ARCHS. The build is
+      # unsigned: the pay suite no longer exercises Universal Links, so no
+      # associated-domains entitlement needs to survive.
       - name: Prepare Flutter iOS artifacts
         working-directory: packages/reown_walletkit/example
         run: |
@@ -291,30 +288,7 @@ jobs:
         working-directory: packages/reown_walletkit/example/ios
         run: pod install
 
-      # iOS resolves Universal Links via the AASA file, which it fetches through
-      # Apple's CDN — often stale/missing on a fresh simulator, so the link opens
-      # Safari instead of the wallet. Appending `?mode=developer` to each associated
-      # domain makes the simulator fetch the AASA directly from the origin server,
-      # bypassing the CDN. Patched only here (CI runner); the committed entitlements
-      # file is untouched, so release builds keep reading the clean file.
-      - name: Enable associated-domains developer mode (Maestro build only)
-        run: |
-          set -euo pipefail
-          PB=/usr/libexec/PlistBuddy
-          ENT=packages/reown_walletkit/example/ios/Runner/Runner.entitlements
-          KEY=":com.apple.developer.associated-domains"
-          i=0
-          while val=$("$PB" -c "Print $KEY:$i" "$ENT" 2>/dev/null); do
-            case "$val" in
-              applinks:*'?mode=developer') ;;
-              applinks:*) "$PB" -c "Set $KEY:$i ${val}?mode=developer" "$ENT" ;;
-            esac
-            i=$((i + 1))
-          done
-          echo "Patched applinks entries in $ENT:"
-          "$PB" -c "Print $KEY" "$ENT"
-
-      - name: Build Runner.app via xcodebuild (automatic signing)
+      - name: Build Runner.app via xcodebuild (unsigned)
         id: build_ios
         working-directory: packages/reown_walletkit/example/ios
         # Build the simulator app for x86_64. mobile_scanner pulls in Google
@@ -337,13 +311,8 @@ jobs:
               -derivedDataPath ../build/ios-ddcache \
               ARCHS=x86_64 \
               ONLY_ACTIVE_ARCH=NO \
-              CODE_SIGNING_ALLOWED=YES \
-              CODE_SIGN_STYLE=Automatic \
-              DEVELOPMENT_TEAM=W5R8AG9K22 \
-              PROVISIONING_PROFILE_SPECIFIER= \
+              CODE_SIGNING_ALLOWED=NO \
               build
-          codesign --display --entitlements - \
-            "../build/ios-ddcache/Build/Products/Debug-internal-iphonesimulator/Runner.app"
 
       - name: Boot iOS simulator
         run: |
@@ -361,8 +330,6 @@ jobs:
           xcrun simctl boot "$SIMULATOR_UDID" 2>/dev/null || true
           # Wait for full boot before configuring the simulator
           xcrun simctl bootstatus "$SIMULATOR_UDID" -b
-          # Reset associated-domains state before install so the applinks binding isn't wiped later
-          xcrun simctl spawn booted swcutil reset || true
           # Disable UIKit animations to reduce Maestro timing flakiness
           xcrun simctl spawn booted defaults write com.apple.UIKit UIAnimationDragCoefficient -float 0 || true
 
@@ -377,25 +344,16 @@ jobs:
           fi
           echo "Installing: $APP_PATH"
           xcrun simctl install booted "$APP_PATH"
-          # Prime the associated-domains cache for the pay Universal Link domains
-          for domain in pay.walletconnect.com staging.pay.walletconnect.com dev.pay.walletconnect.com lab.reown.com; do
-            xcrun simctl spawn booted swcutil dl -d "$domain" || true
-          done
-          sleep 3
-          echo "=== swcutil show (after install + priming) ==="
-          xcrun simctl spawn booted swcutil show || true
 
       - name: Copy Maestro Pay test flows
-        uses: WalletConnect/actions/maestro/pay-tests@ddc7c0f9acd8b1576e9a78f0ef67f4b8fbb36db2
+        uses: WalletConnect/actions/maestro/pay-tests@28181b5f133836380d2d9bb8ff06af5c3234fb9d
 
       - name: Install Maestro CLI
-        uses: WalletConnect/actions/maestro/setup@ddc7c0f9acd8b1576e9a78f0ef67f4b8fbb36db2
+        uses: WalletConnect/actions/maestro/setup@28181b5f133836380d2d9bb8ff06af5c3234fb9d
 
       - name: Run Maestro iOS tests
         id: maestro_ios
         run: |
-          echo "=== swcutil show (Maestro run start) ==="
-          xcrun simctl spawn booted swcutil show || true
           maestro test \
             --env APP_ID=com.walletconnect.flutterwallet.internal \
             --env WPAY_CUSTOMER_KEY_SINGLE_NOKYC=${{ secrets.WPAY_CUSTOMER_KEY_SINGLE_NOKYC }} \
@@ -416,7 +374,7 @@ jobs:
       - name: Reset USDT Permit2 allowance (Polygon)
         if: always()
         continue-on-error: true
-        uses: WalletConnect/actions/maestro/permit2-reset@ddc7c0f9acd8b1576e9a78f0ef67f4b8fbb36db2
+        uses: WalletConnect/actions/maestro/permit2-reset@28181b5f133836380d2d9bb8ff06af5c3234fb9d
         with:
           chain-id: eip155:137
           rpc-url: https://polygon-bor-rpc.publicnode.com

--- a/.github/workflows/ci_e2e_pay_tests.yml
+++ b/.github/workflows/ci_e2e_pay_tests.yml
@@ -113,10 +113,10 @@ jobs:
             --split-per-abi
 
       - name: Copy Maestro Pay test flows
-        uses: WalletConnect/actions/maestro/pay-tests@28181b5f133836380d2d9bb8ff06af5c3234fb9d
+        uses: WalletConnect/actions/maestro/pay-tests@4be7c0112f9651fc63b18c137650b75d2fc9b200
 
       - name: Install Maestro CLI
-        uses: WalletConnect/actions/maestro/setup@28181b5f133836380d2d9bb8ff06af5c3234fb9d
+        uses: WalletConnect/actions/maestro/setup@4be7c0112f9651fc63b18c137650b75d2fc9b200
 
       - name: Setup Android SDK
         uses: android-actions/setup-android@v3
@@ -160,7 +160,7 @@ jobs:
       - name: Reset USDT Permit2 allowance (Polygon)
         if: always()
         continue-on-error: true
-        uses: WalletConnect/actions/maestro/permit2-reset@28181b5f133836380d2d9bb8ff06af5c3234fb9d
+        uses: WalletConnect/actions/maestro/permit2-reset@4be7c0112f9651fc63b18c137650b75d2fc9b200
         with:
           chain-id: eip155:137
           rpc-url: https://polygon-bor-rpc.publicnode.com
@@ -346,10 +346,10 @@ jobs:
           xcrun simctl install booted "$APP_PATH"
 
       - name: Copy Maestro Pay test flows
-        uses: WalletConnect/actions/maestro/pay-tests@28181b5f133836380d2d9bb8ff06af5c3234fb9d
+        uses: WalletConnect/actions/maestro/pay-tests@4be7c0112f9651fc63b18c137650b75d2fc9b200
 
       - name: Install Maestro CLI
-        uses: WalletConnect/actions/maestro/setup@28181b5f133836380d2d9bb8ff06af5c3234fb9d
+        uses: WalletConnect/actions/maestro/setup@4be7c0112f9651fc63b18c137650b75d2fc9b200
 
       - name: Run Maestro iOS tests
         id: maestro_ios
@@ -374,7 +374,7 @@ jobs:
       - name: Reset USDT Permit2 allowance (Polygon)
         if: always()
         continue-on-error: true
-        uses: WalletConnect/actions/maestro/permit2-reset@28181b5f133836380d2d9bb8ff06af5c3234fb9d
+        uses: WalletConnect/actions/maestro/permit2-reset@4be7c0112f9651fc63b18c137650b75d2fc9b200
         with:
           chain-id: eip155:137
           rpc-url: https://polygon-bor-rpc.publicnode.com

--- a/packages/reown_walletkit/example/android/app/src/main/AndroidManifest.xml
+++ b/packages/reown_walletkit/example/android/app/src/main/AndroidManifest.xml
@@ -110,18 +110,9 @@
                 <data android:host="appkit-lab.reown.com" />
                 <data android:pathPattern="/flutter_walletkit_internal" />
             </intent-filter>
-            <!-- WalletConnect Pay App Links -->
-            <intent-filter android:autoVerify="true">
-                <action android:name="android.intent.action.VIEW" />
-
-                <category android:name="android.intent.category.DEFAULT" />
-                <category android:name="android.intent.category.BROWSABLE" />
-
-                <data android:scheme="https" android:host="pay.walletconnect.com" />
-                <data android:scheme="https" android:host="staging.pay.walletconnect.com" />
-                <data android:scheme="https" android:host="dev.pay.walletconnect.com" />
-            </intent-filter>
-            <!-- WalletConnect Pay NFC -->
+            <!-- WalletConnect Pay NFC (pay links reach the wallet via NFC;
+                 the https App Links / autoVerify registration for these hosts
+                 was removed — universal-link pay is no longer supported). -->
             <intent-filter>
                 <action android:name="android.nfc.action.NDEF_DISCOVERED" />
 

--- a/packages/reown_walletkit/example/ios/Runner/Runner.entitlements
+++ b/packages/reown_walletkit/example/ios/Runner/Runner.entitlements
@@ -6,9 +6,6 @@
 	<array>
 		<string>applinks:lab.reown.com</string>
 		<string>applinks:appkit-lab.reown.com</string>
-		<string>applinks:pay.walletconnect.com</string>
-		<string>applinks:staging.pay.walletconnect.com</string>
-		<string>applinks:dev.pay.walletconnect.com</string>
 	</array>
     <!-- <key>aps-environment</key>
     <string>production</string> -->

--- a/packages/reown_walletkit/example/lib/dependencies/deep_link_handler.dart
+++ b/packages/reown_walletkit/example/lib/dependencies/deep_link_handler.dart
@@ -49,6 +49,10 @@ class DeepLinkHandler {
   //     Uri.parse(_walletKit.metadata.redirect?.universal ?? '');
   // static String get host => universalUri.host;
 
+  // Pay links reach the wallet via NFC (the NDEF_DISCOVERED intent-filter on
+  // Android / associated NFC delivery on iOS). Universal-link registration for
+  // these hosts was removed from AndroidManifest.xml / Runner.entitlements, so
+  // on native these URLs now arrive via NFC rather than a tapped App Link.
   static const _payHosts = [
     'pay.walletconnect.com',
     'staging.pay.walletconnect.com',

--- a/scripts/setup-maestro-pay-tests.sh
+++ b/scripts/setup-maestro-pay-tests.sh
@@ -5,7 +5,7 @@
 
 set -euo pipefail
 
-REF="${1:-28181b5f133836380d2d9bb8ff06af5c3234fb9d}"
+REF="${1:-4be7c0112f9651fc63b18c137650b75d2fc9b200}"
 REPO="WalletConnect/actions"
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 ROOT_DIR="$(dirname "$SCRIPT_DIR")"

--- a/scripts/setup-maestro-pay-tests.sh
+++ b/scripts/setup-maestro-pay-tests.sh
@@ -5,7 +5,7 @@
 
 set -euo pipefail
 
-REF="${1:-d385e7a80fb4a3d378ee685021f3f7e24ccdf291}"
+REF="${1:-28181b5f133836380d2d9bb8ff06af5c3234fb9d}"
 REPO="WalletConnect/actions"
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 ROOT_DIR="$(dirname "$SCRIPT_DIR")"


### PR DESCRIPTION
## Summary

Flutter mirror of [reown-com/react-native-examples#563](https://github.com/reown-com/react-native-examples/pull/563).

Universal linking is no longer in scope for the wallet Maestro pay suite — [WalletConnect/actions#109](https://github.com/WalletConnect/actions/pull/109) removes the Universal Link pay test (`pay_single_option_nokyc_deeplink.yaml`) from the shared suite. This PR strips the infrastructure in this repo that existed **only** to make that test pass. Pay links still reach the wallet via **NFC**.

## Changes

- **Stop registering `pay.walletconnect` universal links** — remove the `https` App Links `autoVerify` intent-filter (`AndroidManifest.xml`) and the `applinks:pay.walletconnect.*` entries (`ios/Runner/Runner.entitlements`). Kept `lab.reown.com` / `appkit-lab.reown.com` (real dApp deep-link-back / link-mode) and the NFC `NDEF_DISCOVERED` intent-filter. The Dart pay-link handler (`deep_link_handler.dart`) is unchanged — pay links still route to the pay flow, they just arrive via NFC now.
- **Build the Maestro iOS simulator app unsigned** (`ci_e2e_pay_tests.yml`): `CODE_SIGNING_ALLOWED=NO`, drop `DEVELOPMENT_TEAM` / `CODE_SIGN_STYLE` / `PROVISIONING_PROFILE_SPECIFIER`. Signing (dev, never prod) was only needed so the `applinks:` associated-domains entitlement survived for the UL test. `ARCHS=x86_64` is kept — that's the mobile_scanner/MLKit simulator-slice workaround, unrelated to UL.
- **Remove the iOS UL plumbing**: the associated-domains developer-mode entitlement patch, `swcutil reset`, the AASA-cache priming loop, and the `swcutil show` diagnostic dumps.
- **Bump the shared-flow pins**: `pay-tests`, `setup`, `permit2-reset` (both Android + iOS legs) and the `setup-maestro-pay-tests.sh` default `REF` re-pointed to the 109 merge commit (`4be7c01`) so the deeplink flow is no longer downloaded.

No web leg / `WEB_SKIP_FLOWS` exists in this suite (unlike RN), so nothing there to change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)