### PR TITLE
fix(walletkit-example): use CocoaPods CDN source for iOS pods

### DIFF
--- a/packages/reown_walletkit/example/ios/Podfile
+++ b/packages/reown_walletkit/example/ios/Podfile
@@ -1,5 +1,9 @@
-# Use git source to avoid CDN propagation delays
-source 'https://github.com/CocoaPods/Specs.git'
+# Use the CocoaPods CDN. The legacy git Specs repo requires cloning ~837k
+# files, which collides on macOS's case-insensitive filesystem and
+# intermittently breaks `pod install` in CI. Temporarily switch back to the
+# git source only when validating a freshly-published pod before it
+# propagates to the CDN.
+source 'https://cdn.cocoapods.org/'
 
 # Uncomment this line to define a global platform for your project
 platform :ios, '15.5'

--- a/packages/reown_walletkit/example/ios/Podfile.lock
+++ b/packages/reown_walletkit/example/ios/Podfile.lock
@@ -17,13 +17,13 @@ PODS:
     - GoogleToolboxForMac/Defines (= 4.2.1)
   - "GoogleToolboxForMac/NSData+zlib (4.2.1)":
     - GoogleToolboxForMac/Defines (= 4.2.1)
-  - GoogleUtilities/Environment (8.1.0):
+  - GoogleUtilities/Environment (8.1.2):
     - GoogleUtilities/Privacy
-  - GoogleUtilities/Logger (8.1.0):
+  - GoogleUtilities/Logger (8.1.2):
     - GoogleUtilities/Environment
     - GoogleUtilities/Privacy
-  - GoogleUtilities/Privacy (8.1.0)
-  - GoogleUtilities/UserDefaults (8.1.0):
+  - GoogleUtilities/Privacy (8.1.2)
+  - GoogleUtilities/UserDefaults (8.1.2):
     - GoogleUtilities/Logger
     - GoogleUtilities/Privacy
   - GTMSessionFetcher/Core (3.5.0)
@@ -58,11 +58,11 @@ PODS:
   - reown_yttrium_utils (0.0.1):
     - Flutter
     - YttriumUtilsWrapper (= 0.10.57)
-  - Sentry/HybridSDK (8.58.3)
-  - sentry_flutter (9.22.0):
+  - Sentry/HybridSDK (8.58.4)
+  - sentry_flutter (9.25.0):
     - Flutter
     - FlutterMacOS
-    - Sentry/HybridSDK (= 8.58.3)
+    - Sentry/HybridSDK (= 8.58.4)
   - shared_preferences_foundation (0.0.1):
     - Flutter
     - FlutterMacOS
@@ -95,7 +95,7 @@ DEPENDENCIES:
   - webview_flutter_wkwebview (from `.symlinks/plugins/webview_flutter_wkwebview/darwin`)
 
 SPEC REPOS:
-  https://github.com/CocoaPods/Specs.git:
+  trunk:
     - GoogleDataTransport
     - GoogleMLKit
     - GoogleToolboxForMac
@@ -144,7 +144,7 @@ SPEC CHECKSUMS:
   GoogleDataTransport: aae35b7ea0c09004c3797d53c8c41f66f219d6a7
   GoogleMLKit: eff9e23ec1d90ea4157a1ee2e32a4f610c5b3318
   GoogleToolboxForMac: d1a2cbf009c453f4d6ded37c105e2f67a32206d8
-  GoogleUtilities: 00c88b9a86066ef77f0da2fab05f65d7768ed8e1
+  GoogleUtilities: 766ace00c6b10d8148408f329d10c4f051931850
   GTMSessionFetcher: 5aea5ba6bd522a239e236100971f10cb71b96ab6
   MLImage: 0ad1c5f50edd027672d8b26b0fee78a8b4a0fc56
   MLKitBarcodeScanning: 0a3064da0a7f49ac24ceb3cb46a5bc67496facd2
@@ -155,8 +155,8 @@ SPEC CHECKSUMS:
   package_info_plus: af8e2ca6888548050f16fa2f1938db7b5a5df499
   PromisesObjC: 752c3227f599e3467650e47ea36f433eeb10c273
   reown_yttrium_utils: f6834c869af607ef3e35bd4a5a1279d8a6e9205b
-  Sentry: 108fdbb76299c4189af12246bf0308c09c278922
-  sentry_flutter: fbb8a76a5a009ce7ba7bde295ee6b50b11916851
+  Sentry: 5321d74bdd28d6f6f8beaa1ca06f1fdc746bff49
+  sentry_flutter: d6279f3b5156b6535e2159e03437b571a24cc648
   shared_preferences_foundation: 7036424c3d8ec98dfe75ff1667cb0cd531ec82bb
   sqflite_darwin: 20b2a3a3b70e43edae938624ce550a3cbf66a3d0
   url_launcher_ios: 7a95fa5b60cc718a708b8f2966718e93db0cef1b
@@ -165,6 +165,6 @@ SPEC CHECKSUMS:
   YttriumUtilsWrapper: 6b8e25838fc8a62098b562ca650682040cf9f0bc
   YttriumWrapper: f00470f57bbfa858d346d9a70503c7cc8e10e1e3
 
-PODFILE CHECKSUM: f7ca775d2d7860d344dee1814c9abc4bf4001527
+PODFILE CHECKSUM: 3130601d0782ae68843182f40b767c7e2eca2510
 
 COCOAPODS: 1.16.2


### PR DESCRIPTION
## Problem

The E2E Pay **iOS** lane (`pay-tests-ios`) intermittently fails at *"Prepare Flutter iOS artifacts"* with:

```
Error: CocoaPods's specs repository is too out-of-date to satisfy dependencies.
Error running pod install
```

This happens even on scheduled runs with **no code change** (e.g. [run 29901663728](https://github.com/reown-com/reown_flutter/actions/runs/29901663728/job/88936852134)).

### Root cause

The example iOS `Podfile` pinned the **legacy git Specs repo**:

```ruby
source 'https://github.com/CocoaPods/Specs.git'
```

Resolving against it clones the entire git Specs repo (~837k files). On macOS's **case-insensitive filesystem**, pods with case-only version differences collide (e.g. `AgoraRtcEngine_iOS/4.5.2.TEST` vs `.../4.5.2.test`), leaving the checkout incomplete so CocoaPods concludes its specs repo can't satisfy the Podfile. The outcome is nondeterministic — hence the flakiness.

## Fix

Switch to the **CocoaPods CDN** (`https://cdn.cocoapods.org/`), which doesn't require the giant git checkout and avoids the collisions entirely.

Verified locally: a clean `pod install --repo-update` on the CDN source resolves and installs all pods successfully.

## Lockfile changes

- `SPEC REPOS: github.com/CocoaPods/Specs.git → trunk` (the source switch)
- Incidental pod version drift from a fresh resolve within existing `^` constraints (`Sentry` 8.58.3→8.58.4, `sentry_flutter` 9.22.0→9.25.0, `GoogleUtilities` 8.1.0→8.1.2). `pubspec.lock` is gitignored, so CI regenerates these on every run regardless.

🤖 Generated with [Claude Code](https://claude.com/claude-code)