### PR TITLE
feat(appkit-dapp): WalletConnect Pay WebView checkout flow

### DIFF
--- a/packages/reown_appkit/example/base/ios/Podfile.lock
+++ b/packages/reown_appkit/example/base/ios/Podfile.lock
@@ -14,11 +14,11 @@ PODS:
     - Flutter
   - package_info_plus (0.4.5):
     - Flutter
-  - Sentry/HybridSDK (8.58.3)
-  - sentry_flutter (9.22.0):
+  - Sentry/HybridSDK (8.58.4)
+  - sentry_flutter (9.25.0):
     - Flutter
     - FlutterMacOS
-    - Sentry/HybridSDK (= 8.58.3)
+    - Sentry/HybridSDK (= 8.58.4)
   - shared_preferences_foundation (0.0.1):
     - Flutter
     - FlutterMacOS
@@ -81,8 +81,8 @@ SPEC CHECKSUMS:
   Flutter: cabc95a1d2626b1b06e7179b784ebcf0c0cde467
   flutter_secure_storage: 1ed9476fba7e7a782b22888f956cce43e2c62f13
   package_info_plus: af8e2ca6888548050f16fa2f1938db7b5a5df499
-  Sentry: 108fdbb76299c4189af12246bf0308c09c278922
-  sentry_flutter: fbb8a76a5a009ce7ba7bde295ee6b50b11916851
+  Sentry: 5321d74bdd28d6f6f8beaa1ca06f1fdc746bff49
+  sentry_flutter: d6279f3b5156b6535e2159e03437b571a24cc648
   shared_preferences_foundation: 7036424c3d8ec98dfe75ff1667cb0cd531ec82bb
   sqflite_darwin: 20b2a3a3b70e43edae938624ce550a3cbf66a3d0
   url_launcher_ios: 7a95fa5b60cc718a708b8f2966718e93db0cef1b

--- a/packages/reown_appkit/example/base/lib/pages/connect_page.dart
+++ b/packages/reown_appkit/example/base/lib/pages/connect_page.dart
@@ -1,8 +1,10 @@
 import 'dart:convert';
 
 import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
 
 import 'package:reown_appkit/reown_appkit.dart';
+import 'package:reown_appkit_dapp/pages/pay_webview_page.dart';
 import 'package:reown_appkit_dapp/utils/constants.dart';
 import 'package:reown_appkit_dapp/utils/crypto/helpers.dart';
 import 'package:reown_appkit_dapp/utils/crypto/tron.dart';
@@ -67,6 +69,54 @@ class ConnectPageState extends State<ConnectPage> {
     return;
   }
 
+  // Reads a Pay gateway URL from the clipboard, appends the WebView params
+  // (returnUrl + preferUniversalLinks) and opens the checkout in a WebView.
+  // Mirrors the React Native sample's `PasteUrlButton`.
+  Future<void> _onPastePaymentUrl() async {
+    final data = await Clipboard.getData(Clipboard.kTextPlain);
+    final raw = data?.text?.trim() ?? '';
+    if (raw.isEmpty) {
+      _showPayError(
+        'No URL in clipboard',
+        'Copy a payment URL, then try again.',
+      );
+      return;
+    }
+
+    final parsed = Uri.tryParse(raw);
+    if (parsed == null || parsed.scheme != 'https') {
+      _showPayError(
+        'Invalid payment URL',
+        'Copy a valid https:// payment URL, then try again.',
+      );
+      return;
+    }
+
+    // Return destination the checkout hands to wallets so the OS routes the
+    // user back after signing. Use the app's configured native redirect.
+    final returnUrl =
+        widget.appKitModal.appKit!.metadata.redirect?.native ??
+        'wcflutterdapp://';
+    final payUrl = buildPayUrl(raw, returnUrl);
+
+    if (!mounted) return;
+    Navigator.of(context).push(
+      MaterialPageRoute(builder: (_) => PayWebViewPage(url: payUrl)),
+    );
+  }
+
+  void _showPayError(String title, String description) {
+    if (!mounted) return;
+    toastification.show(
+      type: ToastificationType.error,
+      title: Text(title),
+      description: Text(description),
+      context: context,
+      autoCloseDuration: const Duration(seconds: 3),
+      alignment: Alignment.bottomCenter,
+    );
+  }
+
   @override
   Widget build(BuildContext context) {
     // Build the list of chain buttons, clear if the textnet changed
@@ -124,6 +174,18 @@ class ConnectPageState extends State<ConnectPage> {
               // ),
               // Divider(color: themeColors.grayGlass010),
               const SizedBox(height: StyleConstants.linear8),
+              Visibility(
+                visible: !widget.appKitModal.isConnected,
+                child: Padding(
+                  padding: const EdgeInsets.symmetric(
+                    horizontal: StyleConstants.linear16,
+                  ),
+                  child: ElevatedButton(
+                    onPressed: _onPastePaymentUrl,
+                    child: const Text('Paste payment URL'),
+                  ),
+                ),
+              ),
               Visibility(
                 visible: widget.appKitModal.isConnected,
                 child: Column(

--- a/packages/reown_appkit/example/base/lib/pages/connect_page.dart
+++ b/packages/reown_appkit/example/base/lib/pages/connect_page.dart
@@ -73,8 +73,17 @@ class ConnectPageState extends State<ConnectPage> {
   // (returnUrl + preferUniversalLinks) and opens the checkout in a WebView.
   // Mirrors the React Native sample's `PasteUrlButton`.
   Future<void> _onPastePaymentUrl() async {
-    final data = await Clipboard.getData(Clipboard.kTextPlain);
-    final raw = data?.text?.trim() ?? '';
+    final String raw;
+    try {
+      final data = await Clipboard.getData(Clipboard.kTextPlain);
+      raw = data?.text?.trim() ?? '';
+    } catch (_) {
+      _showPayError(
+        "Couldn't read clipboard",
+        'Check app permissions, then try again.',
+      );
+      return;
+    }
     if (raw.isEmpty) {
       _showPayError(
         'No URL in clipboard',
@@ -176,14 +185,12 @@ class ConnectPageState extends State<ConnectPage> {
               const SizedBox(height: StyleConstants.linear8),
               Visibility(
                 visible: !widget.appKitModal.isConnected,
-                child: Padding(
-                  padding: const EdgeInsets.symmetric(
-                    horizontal: StyleConstants.linear16,
-                  ),
-                  child: ElevatedButton(
-                    onPressed: _onPastePaymentUrl,
-                    child: const Text('Paste payment URL'),
-                  ),
+                // The enclosing ListView already applies horizontal padding, so
+                // the button is placed directly (no extra Padding) to stay
+                // aligned with the rest of the content.
+                child: ElevatedButton(
+                  onPressed: _onPastePaymentUrl,
+                  child: const Text('Paste payment URL'),
                 ),
               ),
               Visibility(

--- a/packages/reown_appkit/example/base/lib/pages/pay_webview_page.dart
+++ b/packages/reown_appkit/example/base/lib/pages/pay_webview_page.dart
@@ -1,0 +1,180 @@
+import 'dart:convert';
+
+import 'package:flutter/material.dart';
+import 'package:reown_appkit/reown_appkit.dart';
+import 'package:reown_appkit_dapp/widgets/pay_success_view.dart';
+import 'package:toastification/toastification.dart';
+import 'package:url_launcher/url_launcher.dart';
+import 'package:webview_flutter/webview_flutter.dart';
+
+/// A wallet-connect deeplink carries the WC pairing URI in its `uri` query
+/// param (e.g. `https://wallet.example/wc?uri=wc:...`). Universal links and
+/// custom-scheme deeplinks both match, so `preferUniversalLinks` wallets keep
+/// working.
+bool isWalletDeeplink(String url) {
+  try {
+    return Uri.parse(url).queryParameters['uri']?.startsWith('wc:') ?? false;
+  } catch (_) {
+    return false;
+  }
+}
+
+/// Appends the two WebView parameters required by the Pay checkout to the
+/// gateway URL. Never construct the base URL manually — always start from the
+/// `gatewayUrl` returned by the Merchant API.
+String buildPayUrl(String gatewayUrl, String appDeepLink) {
+  final uri = Uri.parse(gatewayUrl);
+  return uri.replace(
+    queryParameters: {
+      ...uri.queryParameters,
+      // The wallet returns here after signing.
+      'returnUrl': appDeepLink,
+      // Open wallets via universal links instead of custom schemes.
+      'preferUniversalLinks': '1',
+    },
+  ).toString();
+}
+
+/// Loads the WalletConnect Pay checkout portal inside a WebView.
+///
+/// Mirrors the React Native sample's `PayWebView` screen:
+/// - intercepts wallet deeplinks (`?uri=wc:...`) and hands them to the OS,
+/// - listens for `PAY_SUCCESS` / `PAY_FAILURE` bridge messages,
+/// - shows a success screen or backs out with a toast on failure.
+///
+/// The [url] must already be built with [buildPayUrl] (i.e. carry `returnUrl`
+/// and `preferUniversalLinks`).
+class PayWebViewPage extends StatefulWidget {
+  const PayWebViewPage({super.key, required this.url});
+
+  final String url;
+
+  @override
+  State<PayWebViewPage> createState() => _PayWebViewPageState();
+}
+
+class _PayWebViewPageState extends State<PayWebViewPage> {
+  late final WebViewController _controller;
+
+  // Once the Pay page reports success we swap the WebView for the success
+  // result screen, mirroring the wallet sample's Pay flow.
+  String? _successMessage;
+
+  @override
+  void initState() {
+    super.initState();
+    _controller = WebViewController()
+      ..setJavaScriptMode(JavaScriptMode.unrestricted)
+      ..setNavigationDelegate(
+        NavigationDelegate(
+          onNavigationRequest: _onNavigationRequest,
+          onWebResourceError: _onWebResourceError,
+        ),
+      )
+      // The hosted checkout calls `window.ReactNativeWebView.postMessage(...)`,
+      // so the channel name must stay `ReactNativeWebView` even on Flutter.
+      ..addJavaScriptChannel(
+        'ReactNativeWebView',
+        onMessageReceived: _onBridgeMessage,
+      )
+      ..loadRequest(Uri.parse(widget.url));
+  }
+
+  Future<NavigationDecision> _onNavigationRequest(
+    NavigationRequest request,
+  ) async {
+    if (isWalletDeeplink(request.url)) {
+      try {
+        final launched = await launchUrl(
+          Uri.parse(request.url),
+          mode: LaunchMode.externalApplication,
+        );
+        if (!launched) {
+          _showError(
+            "Couldn't open wallet",
+            'The wallet app may not be installed.',
+          );
+        }
+      } catch (_) {
+        _showError(
+          "Couldn't open wallet",
+          'The wallet app may not be installed.',
+        );
+      }
+      return NavigationDecision.prevent;
+    }
+    return NavigationDecision.navigate;
+  }
+
+  void _onBridgeMessage(JavaScriptMessage message) {
+    Map<String, dynamic> json;
+    try {
+      json = jsonDecode(message.message) as Map<String, dynamic>;
+    } catch (_) {
+      // Non-JSON message — ignore.
+      return;
+    }
+
+    final type = json['type'] as String?;
+    final success = json['success'] as bool?;
+    final isSuccess = type == 'PAY_SUCCESS' || success == true;
+    final isFailure = type == 'PAY_FAILURE' || success == false;
+
+    if (isSuccess) {
+      if (!mounted) return;
+      setState(() => _successMessage = json['message'] as String? ?? '');
+    } else if (isFailure) {
+      _showError('Payment failed', json['error'] as String?);
+      _goBack();
+    }
+  }
+
+  // A failed main-frame load (network error, DNS failure, unreachable host)
+  // otherwise leaves the user stranded on a blank error page. HTTP errors are
+  // intentionally not handled: they can fire for sub-resources and would eject
+  // a valid session.
+  void _onWebResourceError(WebResourceError error) {
+    if (error.isForMainFrame == false) return;
+    _showError(
+      'Failed to load payment page',
+      'Check your connection and try again.',
+    );
+    _goBack();
+  }
+
+  void _goBack() {
+    if (!mounted) return;
+    Navigator.of(context).pop();
+  }
+
+  void _showError(String title, String? description) {
+    if (!mounted) return;
+    toastification.show(
+      type: ToastificationType.error,
+      title: Text(title),
+      description: description != null ? Text(description) : null,
+      context: context,
+      autoCloseDuration: const Duration(seconds: 3),
+      alignment: Alignment.bottomCenter,
+    );
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    if (_successMessage != null) {
+      return PaySuccessView(
+        message: _successMessage!.isEmpty ? null : _successMessage,
+        onDone: _goBack,
+      );
+    }
+
+    return Scaffold(
+      appBar: AppBar(
+        backgroundColor: ReownAppKitModalTheme.colorsOf(context).background175,
+        foregroundColor: ReownAppKitModalTheme.colorsOf(context).foreground100,
+        title: const Text('Pay'),
+      ),
+      body: WebViewWidget(controller: _controller),
+    );
+  }
+}

--- a/packages/reown_appkit/example/base/lib/pages/pay_webview_page.dart
+++ b/packages/reown_appkit/example/base/lib/pages/pay_webview_page.dart
@@ -122,16 +122,20 @@ class _PayWebViewPageState extends State<PayWebViewPage> {
       return;
     }
 
-    final type = json['type'] as String?;
-    final success = json['success'] as bool?;
-    final isSuccess = type == 'PAY_SUCCESS' || success == true;
-    final isFailure = type == 'PAY_FAILURE' || success == false;
+    // Read fields defensively — a non-string `type`/`message`/`error` (or a
+    // non-bool `success`) from a malformed or malicious message must not throw.
+    final type = json['type'] is String ? json['type'] as String : null;
+    final rawSuccess = json['success'];
+    final isSuccess = type == 'PAY_SUCCESS' || rawSuccess == true;
+    final isFailure = type == 'PAY_FAILURE' || rawSuccess == false;
 
     if (isSuccess) {
       if (!mounted) return;
-      setState(() => _successMessage = json['message'] as String? ?? '');
+      final msg = json['message'];
+      setState(() => _successMessage = msg is String ? msg : '');
     } else if (isFailure) {
-      _showError('Payment failed', json['error'] as String?);
+      final err = json['error'];
+      _showError('Payment failed', err is String ? err : null);
       _goBack();
     }
   }

--- a/packages/reown_appkit/example/base/lib/pages/pay_webview_page.dart
+++ b/packages/reown_appkit/example/base/lib/pages/pay_webview_page.dart
@@ -103,7 +103,14 @@ class _PayWebViewPageState extends State<PayWebViewPage> {
       }
       return NavigationDecision.prevent;
     }
-    return NavigationDecision.navigate;
+    // Allow https (the checkout) and about: (blank/initial). Block any other
+    // scheme so the page can't drive the OS into arbitrary native schemes
+    // (tel:, sms:, intent:, …).
+    final scheme = Uri.tryParse(request.url)?.scheme.toLowerCase();
+    if (scheme == 'https' || scheme == 'about') {
+      return NavigationDecision.navigate;
+    }
+    return NavigationDecision.prevent;
   }
 
   void _onBridgeMessage(JavaScriptMessage message) {

--- a/packages/reown_appkit/example/base/lib/pages/pay_webview_page.dart
+++ b/packages/reown_appkit/example/base/lib/pages/pay_webview_page.dart
@@ -134,7 +134,10 @@ class _PayWebViewPageState extends State<PayWebViewPage> {
   // intentionally not handled: they can fire for sub-resources and would eject
   // a valid session.
   void _onWebResourceError(WebResourceError error) {
-    if (error.isForMainFrame == false) return;
+    // Only act on a confirmed main-frame failure. `isForMainFrame` is nullable
+    // (iOS/WKWebView leaves it null), and treating null/false as "eject" would
+    // dismiss a live checkout on a failing sub-resource (analytics, pixels…).
+    if (error.isForMainFrame != true) return;
     _showError(
       'Failed to load payment page',
       'Check your connection and try again.',

--- a/packages/reown_appkit/example/base/lib/widgets/pay_success_view.dart
+++ b/packages/reown_appkit/example/base/lib/widgets/pay_success_view.dart
@@ -1,0 +1,58 @@
+import 'package:flutter/material.dart';
+import 'package:reown_appkit/reown_appkit.dart';
+
+/// Result screen shown after the Pay checkout reports `PAY_SUCCESS`.
+///
+/// Mirrors the React Native sample's `PaySuccessView`, but uses a plain
+/// Material check icon instead of a Lottie animation to avoid an extra
+/// dependency in the example app.
+class PaySuccessView extends StatelessWidget {
+  const PaySuccessView({super.key, this.message, required this.onDone});
+
+  /// Optional human-readable confirmation summary from the checkout.
+  final String? message;
+
+  /// Called when the user taps "Done".
+  final VoidCallback onDone;
+
+  @override
+  Widget build(BuildContext context) {
+    final themeColors = ReownAppKitModalTheme.colorsOf(context);
+    return Scaffold(
+      backgroundColor: themeColors.background125,
+      body: SafeArea(
+        child: Center(
+          child: Padding(
+            padding: const EdgeInsets.all(24.0),
+            child: Column(
+              mainAxisSize: MainAxisSize.min,
+              crossAxisAlignment: CrossAxisAlignment.center,
+              children: [
+                Icon(
+                  Icons.check_circle,
+                  size: 120.0,
+                  color: themeColors.success100,
+                ),
+                const SizedBox(height: 24.0),
+                Text(
+                  message?.isNotEmpty == true ? message! : 'Payment confirmed',
+                  textAlign: TextAlign.center,
+                  style: TextStyle(
+                    fontSize: 20.0,
+                    fontWeight: FontWeight.w600,
+                    color: themeColors.foreground100,
+                  ),
+                ),
+                const SizedBox(height: 32.0),
+                ElevatedButton(
+                  onPressed: onDone,
+                  child: const Text('Done'),
+                ),
+              ],
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/packages/reown_appkit/example/base/pubspec.yaml
+++ b/packages/reown_appkit/example/base/pubspec.yaml
@@ -25,6 +25,8 @@ dependencies:
     path: ../..
   sentry_flutter: ^9.7.0
   toastification: ^2.3.0
+  url_launcher: ^6.3.1
+  webview_flutter: ^4.10.0
 
 dependency_overrides:
   # because of polkadart: ^0.5.0


### PR DESCRIPTION
## What

Adds a WalletConnect **Pay WebView** checkout flow to the Flutter AppKit **dApp** sample (`packages/reown_appkit/example/base`, "FL AppKit"), mirroring the React Native examples PRs [reown-com/react-native-examples#570](https://github.com/reown-com/react-native-examples/pull/570) and [#576](https://github.com/reown-com/react-native-examples/pull/576) and the [WebView Integration docs](https://docs.reown.com) Flutter snippet.

A **"Paste payment URL"** button on the Connect tab (shown when disconnected) reads a Pay `gatewayUrl` from the clipboard, appends `returnUrl` + `preferUniversalLinks`, and opens the hosted checkout in a native WebView.

## Changes

- **`lib/pages/pay_webview_page.dart`** (new) — `PayWebViewPage` + `isWalletDeeplink`/`buildPayUrl` helpers. Loads the gateway URL, forwards wallet deeplinks (`?uri=wc:`) to the OS via `launchUrl` (awaited + error-handled), handles `PAY_SUCCESS`/`PAY_FAILURE` over the `ReactNativeWebView` JS channel, and backs out on load errors.
- **`lib/widgets/pay_success_view.dart`** (new) — centered success result screen (check + message + Done). No Lottie dependency.
- **`lib/pages/connect_page.dart`** — "Paste payment URL" entry with `https` validation and navigation; `returnUrl` derived from the app's configured `Redirect.native`.
- **`pubspec.yaml`** — add `webview_flutter` + `url_launcher`.
- **`ios/Podfile.lock`** — incidental: Sentry `8.58.3 → 8.58.4` / sentry_flutter `9.22 → 9.25`, needed for the example to resolve pods and build on iOS.

## Notes on the Flutter/webview_flutter specifics

- The JS channel **must** be named `ReactNativeWebView` (the hosted checkout calls `window.ReactNativeWebView.postMessage`). `webview_flutter_wkwebview` auto-injects the `window.ReactNativeWebView` shim at document start, so no manual iOS shim is needed (unlike native Swift).
- DOM storage is enabled by default in `webview_flutter_android`; JS is enabled via `setJavaScriptMode`.
- No multi-window handling needed — the checkout opens wallets via same-frame navigation, which routes through `onNavigationRequest`.

## Testing

- ✅ Builds & runs on Android emulator and iOS simulator (iPhone 17).
- ✅ Button renders on Connect tab (both platforms).
- ✅ Clipboard read + `https` validation + error toast.
- ✅ Navigation → WebView → **success screen** (verified end-to-end on Android; centered on both).

Full interactive Pay flow (real wallet deeplink + server verification) needs a live merchant `gatewayUrl`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)