### PR TITLE
strip quotes from windows os version in relay user agent

### DIFF
--- a/packages/reown_core/CHANGELOG.md
+++ b/packages/reown_core/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 1.4.1
+
+- Fixed relay connectivity on Windows when the OS version contains double quotes.
+
 ## 1.4.0
 
 - Upgraded `flutter_secure_storage` to `^10.0.0`. Existing data stored via the

--- a/packages/reown_core/lib/utils/utils.dart
+++ b/packages/reown_core/lib/utils/utils.dart
@@ -31,7 +31,7 @@ class ReownCoreUtils {
     return DateTime.now().toUtc().millisecondsSinceEpoch ~/ 1000 + offset;
   }
 
-  /// Strips characters that break WalletConnect relay `ua` validation.
+  /// Strips literal `"` characters that break WalletConnect relay `ua` validation.
   /// Some Windows installs return quoted product names in
   /// [Platform.operatingSystemVersion], e.g. `"Windows 10 Pro" 10.0 (...)`.
   static String sanitizeOSVersion(String version) {

--- a/packages/reown_core/lib/utils/utils.dart
+++ b/packages/reown_core/lib/utils/utils.dart
@@ -35,7 +35,7 @@ class ReownCoreUtils {
   /// Some Windows installs return quoted product names in
   /// [Platform.operatingSystemVersion], e.g. `"Windows 10 Pro" 10.0 (...)`.
   static String sanitizeOSVersion(String version) {
-    return version;
+    return version.replaceAll('"', '');
   }
 
   static String getOS() {
@@ -45,7 +45,7 @@ class ReownCoreUtils {
     } else {
       return <String>[
         Platform.operatingSystem,
-        Platform.operatingSystemVersion,
+        sanitizeOSVersion(Platform.operatingSystemVersion),
       ].join('-');
     }
   }

--- a/packages/reown_core/lib/utils/utils.dart
+++ b/packages/reown_core/lib/utils/utils.dart
@@ -31,6 +31,13 @@ class ReownCoreUtils {
     return DateTime.now().toUtc().millisecondsSinceEpoch ~/ 1000 + offset;
   }
 
+  /// Strips characters that break WalletConnect relay `ua` validation.
+  /// Some Windows installs return quoted product names in
+  /// [Platform.operatingSystemVersion], e.g. `"Windows 10 Pro" 10.0 (...)`.
+  static String sanitizeOSVersion(String version) {
+    return version;
+  }
+
   static String getOS() {
     if (kIsWeb) {
       // TODO change this into an actual value

--- a/packages/reown_core/test/utils_test.dart
+++ b/packages/reown_core/test/utils_test.dart
@@ -7,9 +7,7 @@ void main() {
   group('sanitizeOSVersion', () {
     test('strips double quotes from windows os version strings', () {
       expect(
-        ReownCoreUtils.sanitizeOSVersion(
-          '"Windows 10 Pro" 10.0 (Build 19045)',
-        ),
+        ReownCoreUtils.sanitizeOSVersion('"Windows 10 Pro" 10.0 (Build 19045)'),
         'Windows 10 Pro 10.0 (Build 19045)',
       );
     });

--- a/packages/reown_core/test/utils_test.dart
+++ b/packages/reown_core/test/utils_test.dart
@@ -4,6 +4,24 @@ import 'package:reown_core/reown_core.dart';
 void main() {
   TestWidgetsFlutterBinding.ensureInitialized();
 
+  group('sanitizeOSVersion', () {
+    test('strips double quotes from windows os version strings', () {
+      expect(
+        ReownCoreUtils.sanitizeOSVersion(
+          '"Windows 10 Pro" 10.0 (Build 19045)',
+        ),
+        'Windows 10 Pro 10.0 (Build 19045)',
+      );
+    });
+
+    test('leaves versions without quotes unchanged', () {
+      expect(
+        ReownCoreUtils.sanitizeOSVersion('Version 15.0 (Build 24A335)'),
+        'Version 15.0 (Build 24A335)',
+      );
+    });
+  });
+
   group('recursiveSearchForMapKey', () {
     test(
       'should parse solana_signTransaction/solana_signAndSendTransaction and extract signature',

--- a/packages/walletconnect_pay/CHANGELOG.md
+++ b/packages/walletconnect_pay/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 1.0.2
+
+- Sanitized quoted Windows OS version strings returned by WalletconnectPayUtils.getOS().
+
 ## 1.0.1
 
 - Added WebView-based payment data collection

--- a/packages/walletconnect_pay/lib/walletconnect_pay_utils.dart
+++ b/packages/walletconnect_pay/lib/walletconnect_pay_utils.dart
@@ -4,14 +4,18 @@ import 'package:package_info_plus/package_info_plus.dart';
 import 'package:walletconnect_pay/version.dart' show packageVersion;
 
 class WalletconnectPayUtils {
+  /// Strips literal `"` characters from OS version strings used in ua/headers.
+  static String sanitizeOSVersion(String version) {
+    return version.replaceAll('"', '');
+  }
+
   static String getOS() {
     if (kIsWeb) {
       return 'web-browser';
     } else {
       return <String>[
         Platform.operatingSystem,
-        // Some Windows installs quote the product name; strip for ua safety.
-        Platform.operatingSystemVersion.replaceAll('"', ''),
+        sanitizeOSVersion(Platform.operatingSystemVersion),
       ].join('-');
     }
   }

--- a/packages/walletconnect_pay/lib/walletconnect_pay_utils.dart
+++ b/packages/walletconnect_pay/lib/walletconnect_pay_utils.dart
@@ -10,7 +10,8 @@ class WalletconnectPayUtils {
     } else {
       return <String>[
         Platform.operatingSystem,
-        Platform.operatingSystemVersion,
+        // Some Windows installs quote the product name; strip for ua safety.
+        Platform.operatingSystemVersion.replaceAll('"', ''),
       ].join('-');
     }
   }

--- a/packages/walletconnect_pay/test/walletconnect_pay_utils_test.dart
+++ b/packages/walletconnect_pay/test/walletconnect_pay_utils_test.dart
@@ -104,6 +104,12 @@ void main() {
           expect(os.contains('-'), true);
         }
       });
+
+      test('test_os_does_not_contain_double_quotes', () {
+        final os = WalletconnectPayUtils.getOS();
+
+        expect(os.contains('"'), isFalse);
+      });
     });
 
     group('SDK Headers Configuration', () {

--- a/packages/walletconnect_pay/test/walletconnect_pay_utils_test.dart
+++ b/packages/walletconnect_pay/test/walletconnect_pay_utils_test.dart
@@ -110,6 +110,15 @@ void main() {
 
         expect(os.contains('"'), isFalse);
       });
+
+      test('test_sanitize_os_version_strips_double_quotes', () {
+        expect(
+          WalletconnectPayUtils.sanitizeOSVersion(
+            '"Windows 10 Pro" 10.0 (Build 19045)',
+          ),
+          'Windows 10 Pro 10.0 (Build 19045)',
+        );
+      });
     });
 
     group('SDK Headers Configuration', () {


### PR DESCRIPTION
## Summary
- Sanitize `Platform.operatingSystemVersion` before building the WalletConnect relay `ua` string so Windows installs that return quoted product names (e.g. `"Windows 10 Pro"`) no longer fail the WebSocket upgrade with 403.
- Apply the same strip in `walletconnect_pay` `getOS()`.
- Add regression coverage for quote stripping in `reown_core` and a no-quotes assertion in `walletconnect_pay`.

Resolves #355

## How Has This Been Tested?
- `fvm flutter test test/utils_test.dart` in `packages/reown_core`
- `fvm flutter test test/walletconnect_pay_utils_test.dart` in `packages/walletconnect_pay`
- `fvm flutter analyze` on touched files

## Due Diligence
* [ ] Breaking change
* [ ] Requires a documentation update