### PR TITLE
ci(release): auto-create GitHub Releases from pub.dev publishes

### DIFF
--- a/.github/scripts/create_github_releases.sh
+++ b/.github/scripts/create_github_releases.sh
@@ -155,15 +155,16 @@ process() {
   fi
 
   local -a args
-  args=(release create "$tag" --title "$tag" --generate-notes --latest=false)
+  args=(release create "$tag" --title "$tag" --latest=false)
 
   local prev
   prev="$(previous_tag "$name" "$version")"
   if [[ -n "$prev" ]]; then
-    args+=(--notes-start-tag "$prev")
+    args+=(--generate-notes --notes-start-tag "$prev")
     log "${tag}: notes generated since ${prev}"
   else
-    log "${tag}: no prior same-package tag; GitHub picks its default baseline"
+    args+=(--notes "Initial automated release for ${name} ${version}.")
+    log "${tag}: no prior same-package tag; using an explicit initial-release note"
   fi
 
   # Tag exists without a release -> attach to the existing (verified) tag.

--- a/.github/scripts/create_github_releases.sh
+++ b/.github/scripts/create_github_releases.sh
@@ -28,7 +28,11 @@
 #
 set -euo pipefail
 
-# The eight published packages. dir == package name for all of them.
+# The eight packages that have a publish job in publish-packages.yml
+# (dir == package name for all of them). This list MUST mirror those jobs:
+# a manifest can only ever contain packages that were actually published there.
+# reown_yttrium_utils is intentionally excluded — it has no publish job, so it
+# never appears in a manifest. Add it here only if/when a publish job is added.
 ALLOWLIST=(
   reown_core
   reown_sign

--- a/.github/scripts/create_github_releases.sh
+++ b/.github/scripts/create_github_releases.sh
@@ -223,8 +223,8 @@ process_manual() {
     fi
     # Use Ruby's stdlib YAML (preinstalled on GitHub runners) — avoids an
     # unpinned yq download in the release workflow.
-    pubname="$(ruby -ryaml -e 'puts (YAML.load_file(ARGV[0])["name"]).to_s' "$ps")"
-    version="$(ruby -ryaml -e 'puts (YAML.load_file(ARGV[0])["version"]).to_s' "$ps")"
+    pubname="$(ruby -ryaml -e 'puts (YAML.safe_load(File.read(ARGV[0]), permitted_classes: [], permitted_symbols: [], aliases: false)["name"]).to_s' "$ps")"
+    version="$(ruby -ryaml -e 'puts (YAML.safe_load(File.read(ARGV[0]), permitted_classes: [], permitted_symbols: [], aliases: false)["version"]).to_s' "$ps")"
     [[ "$pubname" == "$name" ]] || die "pubspec name '${pubname}' != expected '${name}' in ${ps}"
     [[ -n "$version" ]] || die "no version found in ${ps}"
     process "$name" "$version" "false"

--- a/.github/scripts/create_github_releases.sh
+++ b/.github/scripts/create_github_releases.sh
@@ -1,0 +1,235 @@
+#!/usr/bin/env bash
+#
+# create_github_releases.sh
+#
+# Creates one GitHub Release per published package version, named
+# "<package_name>-v<version>" (e.g. reown_core-v1.4.0), targeting a specific
+# commit SHA. Creating a release also creates its lightweight tag when absent.
+#
+# Two modes (env MODE):
+#   manifest  - read the committed release manifest (the normal, automated path
+#               driven by the merged release PR). Every listed version MUST be on
+#               pub.dev or the run fails.
+#   manual    - scan the fixed package list's CURRENT pubspec versions
+#               (workflow_dispatch recovery/backfill). Versions not yet on
+#               pub.dev are skipped, not failed.
+#
+# Required env:
+#   MODE           manifest | manual
+#   TARGET_SHA     commit the releases point at
+#   GH_TOKEN       token for the gh CLI (contents: write)
+# Manifest mode:
+#   MANIFEST_PATH  path to publish_workflow_<n>.json
+# Optional env:
+#   DRY_RUN        "true" prints intended actions, creates nothing (default false)
+#   SUMMARY_FILE   file to append created tag names to (one per line), for Slack
+#   PUBDEV_MAX_ATTEMPTS  transient-retry attempts (default 10)
+#   PUBDEV_SLEEP         seconds between attempts (default 6)
+#
+set -euo pipefail
+
+# The eight published packages. dir == package name for all of them.
+ALLOWLIST=(
+  reown_core
+  reown_sign
+  reown_appkit
+  reown_walletkit
+  reown_yttrium
+  reown_cli
+  pos_client
+  walletconnect_pay
+)
+
+MODE="${MODE:?MODE is required (manifest|manual)}"
+TARGET_SHA="${TARGET_SHA:?TARGET_SHA is required}"
+DRY_RUN="${DRY_RUN:-false}"
+SUMMARY_FILE="${SUMMARY_FILE:-}"
+PUBDEV_MAX_ATTEMPTS="${PUBDEV_MAX_ATTEMPTS:-10}"
+PUBDEV_SLEEP="${PUBDEV_SLEEP:-6}"
+
+log()  { echo "[create-releases] $*"; }
+die()  { echo "[create-releases][FATAL] $*" >&2; exit 1; }
+
+if [[ -n "$SUMMARY_FILE" ]]; then
+  : > "$SUMMARY_FILE"
+fi
+
+in_allowlist() {
+  local needle="$1" p
+  for p in "${ALLOWLIST[@]}"; do
+    [[ "$p" == "$needle" ]] && return 0
+  done
+  return 1
+}
+
+# Echo the HTTP status for a pub.dev version, "000" on curl failure.
+pubdev_status() {
+  local name="$1" version="$2"
+  curl -s -o /dev/null -w "%{http_code}" --max-time 15 \
+    "https://pub.dev/api/packages/${name}/versions/${version}" 2>/dev/null || echo "000"
+}
+
+# 0 = published (200), 1 = definitively absent (404),
+# 2 = transient/unknown after retries.
+verify_pubdev() {
+  local name="$1" version="$2" attempt status
+  for (( attempt=1; attempt<=PUBDEV_MAX_ATTEMPTS; attempt++ )); do
+    status="$(pubdev_status "$name" "$version")"
+    case "$status" in
+      200) return 0 ;;
+      404) return 1 ;;
+      *)
+        log "pub.dev ${name} ${version}: attempt ${attempt}/${PUBDEV_MAX_ATTEMPTS} -> HTTP ${status}; retrying in ${PUBDEV_SLEEP}s"
+        sleep "$PUBDEV_SLEEP"
+        ;;
+    esac
+  done
+  return 2
+}
+
+# Highest same-package tag strictly below $version, reachable from TARGET_SHA.
+# Echoes the full tag (e.g. "reown_core-v1.3.9") or nothing.
+previous_tag() {
+  local name="$1" version="$2" vers prev_ver
+  vers="$(git tag --list "${name}-v*" --merged "$TARGET_SHA" 2>/dev/null \
+            | sed -n "s/^${name}-v//p" \
+            | grep -E '^[0-9]+\.' || true)"
+  [[ -z "$vers" ]] && return 0
+  # Append the target version, sort, and take the element immediately before it.
+  prev_ver="$(printf '%s\n%s\n' "$vers" "$version" \
+                | grep -v '^$' \
+                | sort -V \
+                | awk -v v="$version" '$0==v{print last; exit} {last=$0}')"
+  [[ -n "$prev_ver" && "$prev_ver" != "$version" ]] && echo "${name}-v${prev_ver}"
+  return 0
+}
+
+# Create (or safely skip) the release for one {name, version}.
+# require_pubdev=true => a 404 is fatal (manifest asserted it published).
+process() {
+  local name="$1" version="$2" require_pubdev="$3"
+  local tag="${name}-v${version}"
+  log "Processing ${tag} (target ${TARGET_SHA})"
+
+  set +e
+  verify_pubdev "$name" "$version"
+  local rc=$?
+  set -e
+  case "$rc" in
+    0) : ;;
+    1)
+      if [[ "$require_pubdev" == "true" ]]; then
+        die "${tag} not found on pub.dev (HTTP 404) but the manifest asserts it was published"
+      fi
+      log "SKIP ${tag}: not on pub.dev (manual backfill of an unpublished version)"
+      return 0
+      ;;
+    *)
+      die "${tag}: pub.dev verification failed after ${PUBDEV_MAX_ATTEMPTS} attempts (transient/5xx)"
+      ;;
+  esac
+
+  local release_exists=false tag_exists=false tag_sha=""
+  gh release view "$tag" >/dev/null 2>&1 && release_exists=true
+  if git rev-parse -q --verify "refs/tags/${tag}" >/dev/null 2>&1; then
+    tag_exists=true
+    tag_sha="$(git rev-list -n1 "refs/tags/${tag}")"
+  fi
+
+  # Both exist -> verify target (manifest mode) and skip.
+  if [[ "$release_exists" == true && "$tag_exists" == true ]]; then
+    if [[ "$MODE" == "manifest" && "$tag_sha" != "$TARGET_SHA" ]]; then
+      die "${tag} already exists at ${tag_sha}, expected ${TARGET_SHA}"
+    fi
+    log "SKIP ${tag}: release and tag already exist"
+    return 0
+  fi
+
+  # Release without its tag -> broken state.
+  if [[ "$release_exists" == true && "$tag_exists" == false ]]; then
+    die "${tag}: a release exists but its tag ref is missing — broken repository state"
+  fi
+
+  local -a args
+  args=(release create "$tag" --title "$tag" --generate-notes --latest=false)
+
+  local prev
+  prev="$(previous_tag "$name" "$version")"
+  if [[ -n "$prev" ]]; then
+    args+=(--notes-start-tag "$prev")
+    log "${tag}: notes generated since ${prev}"
+  else
+    log "${tag}: no prior same-package tag; GitHub picks its default baseline"
+  fi
+
+  # Tag exists without a release -> attach to the existing (verified) tag.
+  if [[ "$tag_exists" == true ]]; then
+    if [[ "$MODE" == "manifest" && "$tag_sha" != "$TARGET_SHA" ]]; then
+      die "${tag}: existing tag at ${tag_sha} != target ${TARGET_SHA}"
+    fi
+    args+=(--verify-tag)
+  else
+    args+=(--target "$TARGET_SHA")
+  fi
+
+  if [[ "$DRY_RUN" == "true" ]]; then
+    log "DRY_RUN: would run: gh ${args[*]}"
+    return 0
+  fi
+
+  gh "${args[@]}"
+  log "Created release ${tag}"
+  [[ -n "$SUMMARY_FILE" ]] && echo "$tag" >> "$SUMMARY_FILE"
+  return 0
+}
+
+process_manifest() {
+  local mf="${MANIFEST_PATH:?MANIFEST_PATH is required in manifest mode}"
+  [[ -f "$mf" ]] || die "manifest not found: ${mf}"
+
+  local schema count dups
+  schema="$(jq -r '.schema_version' "$mf")"
+  [[ "$schema" == "1" ]] || die "unsupported schema_version: ${schema}"
+
+  count="$(jq '.packages | length' "$mf")"
+  [[ "$count" -ge 1 ]] || die "manifest has no packages"
+
+  dups="$(jq -r '.packages[].name' "$mf" | sort | uniq -d)"
+  [[ -z "$dups" ]] || die "duplicate package names in manifest: ${dups}"
+
+  local i name version
+  for (( i=0; i<count; i++ )); do
+    name="$(jq -r ".packages[$i].name" "$mf")"
+    version="$(jq -r ".packages[$i].version" "$mf")"
+    [[ -n "$name" && "$name" != "null" ]] || die "empty package name at index ${i}"
+    [[ -n "$version" && "$version" != "null" ]] || die "empty version at index ${i}"
+    in_allowlist "$name" || die "package not in allowlist: ${name}"
+    process "$name" "$version" "true"
+  done
+}
+
+process_manual() {
+  local name ps version pubname
+  for name in "${ALLOWLIST[@]}"; do
+    ps="packages/${name}/pubspec.yaml"
+    if [[ ! -f "$ps" ]]; then
+      log "SKIP ${name}: no pubspec at ${ps}"
+      continue
+    fi
+    # Use Ruby's stdlib YAML (preinstalled on GitHub runners) — avoids an
+    # unpinned yq download in the release workflow.
+    pubname="$(ruby -ryaml -e 'puts (YAML.load_file(ARGV[0])["name"]).to_s' "$ps")"
+    version="$(ruby -ryaml -e 'puts (YAML.load_file(ARGV[0])["version"]).to_s' "$ps")"
+    [[ "$pubname" == "$name" ]] || die "pubspec name '${pubname}' != expected '${name}' in ${ps}"
+    [[ -n "$version" ]] || die "no version found in ${ps}"
+    process "$name" "$version" "false"
+  done
+}
+
+case "$MODE" in
+  manifest) process_manifest ;;
+  manual)   process_manual ;;
+  *)        die "unknown MODE: ${MODE} (expected manifest|manual)" ;;
+esac
+
+log "Done."

--- a/.github/workflows/publish-packages.yml
+++ b/.github/workflows/publish-packages.yml
@@ -212,6 +212,7 @@ jobs:
       - name: Post a message in a channel
         uses: slackapi/slack-github-action@v2.1.0
         if: github.event.inputs.core == 'true'
+        continue-on-error: true
         with:
           webhook: ${{ secrets.SLACK_WEBHOOK_URL }}
           webhook-type: incoming-webhook
@@ -332,6 +333,7 @@ jobs:
       - name: Post a message in a channel
         uses: slackapi/slack-github-action@v2.1.0
         if: github.event.inputs.sign == 'true'
+        continue-on-error: true
         with:
           webhook: ${{ secrets.SLACK_WEBHOOK_URL }}
           webhook-type: incoming-webhook
@@ -463,6 +465,7 @@ jobs:
       - name: Post a message in a channel
         uses: slackapi/slack-github-action@v2.1.0
         if: github.event.inputs.appkit == 'true'
+        continue-on-error: true
         with:
           webhook: ${{ secrets.SLACK_WEBHOOK_URL }}
           webhook-type: incoming-webhook
@@ -597,6 +600,7 @@ jobs:
       - name: Post a message in a channel
         uses: slackapi/slack-github-action@v2.1.0
         if: github.event.inputs.walletkit == 'true'
+        continue-on-error: true
         with:
           webhook: ${{ secrets.SLACK_WEBHOOK_URL }}
           webhook-type: incoming-webhook
@@ -694,6 +698,7 @@ jobs:
       - name: Post a message in a channel
         uses: slackapi/slack-github-action@v2.1.0
         if: github.event.inputs.yttrium == 'true'
+        continue-on-error: true
         with:
           webhook: ${{ secrets.SLACK_WEBHOOK_URL }}
           webhook-type: incoming-webhook
@@ -791,6 +796,7 @@ jobs:
       - name: Post a message in a channel
         uses: slackapi/slack-github-action@v2.1.0
         if: github.event.inputs.cli == 'true'
+        continue-on-error: true
         with:
           webhook: ${{ secrets.SLACK_WEBHOOK_URL }}
           webhook-type: incoming-webhook
@@ -888,6 +894,7 @@ jobs:
       - name: Post a message in a channel
         uses: slackapi/slack-github-action@v2.1.0
         if: github.event.inputs.pos == 'true'
+        continue-on-error: true
         with:
           webhook: ${{ secrets.SLACK_WEBHOOK_URL }}
           webhook-type: incoming-webhook
@@ -986,6 +993,7 @@ jobs:
       - name: Post a message in a channel
         uses: slackapi/slack-github-action@v2.1.0
         if: github.event.inputs.walletconnect_pay == 'true'
+        continue-on-error: true
         with:
           webhook: ${{ secrets.SLACK_WEBHOOK_URL }}
           webhook-type: incoming-webhook
@@ -1007,7 +1015,17 @@ jobs:
         publish-walletconnect-pay,
       ]
     runs-on: ubuntu-latest
-    if: always() && (needs.publish-core.result == 'success' || needs.publish-sign.result == 'success' || needs.publish-appkit.result == 'success' || needs.publish-walletkit.result == 'success' || needs.publish-yttrium.result == 'success' || needs.publish-cli.result == 'success' || needs.publish-pos.result == 'success' || needs.publish-walletconnect-pay.result == 'success')
+    if: >-
+      always() && (
+        needs.publish-core.outputs.published == 'true' ||
+        needs.publish-sign.outputs.published == 'true' ||
+        needs.publish-appkit.outputs.published == 'true' ||
+        needs.publish-walletkit.outputs.published == 'true' ||
+        needs.publish-yttrium.outputs.published == 'true' ||
+        needs.publish-cli.outputs.published == 'true' ||
+        needs.publish-pos.outputs.published == 'true' ||
+        needs.publish-walletconnect-pay.outputs.published == 'true'
+      )
     steps:
       - name: Checkout code
         uses: actions/checkout@v4

--- a/.github/workflows/publish-packages.yml
+++ b/.github/workflows/publish-packages.yml
@@ -106,6 +106,7 @@ jobs:
     runs-on: ubuntu-latest
     outputs:
       package_version: ${{ steps.get_version.outputs.version }}
+      published: ${{ steps.mark_published.outputs.published }}
     steps:
       - name: Check if reown_core should be published
         if: github.event.inputs.core == 'false'
@@ -201,6 +202,11 @@ jobs:
           chmod +x .github/scripts/wait_for_package.sh
           .github/scripts/wait_for_package.sh reown_core ${{ steps.get_version.outputs.version }}
 
+      - name: Mark reown_core as published
+        id: mark_published
+        if: github.event.inputs.core == 'true'
+        run: echo "published=true" >> "$GITHUB_OUTPUT"
+
       - name: Post a message in a channel
         uses: slackapi/slack-github-action@v2.1.0
         if: github.event.inputs.core == 'true'
@@ -216,6 +222,7 @@ jobs:
     runs-on: ubuntu-latest
     outputs:
       package_version: ${{ steps.get_version.outputs.version }}
+      published: ${{ steps.mark_published.outputs.published }}
     steps:
       - name: Check if reown_sign should be published
         if: github.event.inputs.sign == 'false'
@@ -311,6 +318,11 @@ jobs:
           chmod +x .github/scripts/wait_for_package.sh
           .github/scripts/wait_for_package.sh reown_sign ${{ steps.get_version.outputs.version }}
 
+      - name: Mark reown_sign as published
+        id: mark_published
+        if: github.event.inputs.sign == 'true'
+        run: echo "published=true" >> "$GITHUB_OUTPUT"
+
       - name: Post a message in a channel
         uses: slackapi/slack-github-action@v2.1.0
         if: github.event.inputs.sign == 'true'
@@ -324,6 +336,9 @@ jobs:
     name: Publish reown_appkit
     needs: [create-branch, publish-core, publish-sign]
     runs-on: ubuntu-latest
+    outputs:
+      package_version: ${{ steps.get_version.outputs.version }}
+      published: ${{ steps.mark_published.outputs.published }}
     steps:
       - name: Check if reown_appkit should be published
         if: github.event.inputs.appkit == 'false'
@@ -430,6 +445,11 @@ jobs:
           chmod +x .github/scripts/wait_for_package.sh
           .github/scripts/wait_for_package.sh reown_appkit ${{ steps.get_version.outputs.version }}
 
+      - name: Mark reown_appkit as published
+        id: mark_published
+        if: github.event.inputs.appkit == 'true'
+        run: echo "published=true" >> "$GITHUB_OUTPUT"
+
       - name: Post a message in a channel
         uses: slackapi/slack-github-action@v2.1.0
         if: github.event.inputs.appkit == 'true'
@@ -443,6 +463,9 @@ jobs:
     name: Publish reown_walletkit
     needs: [create-branch, publish-core, publish-sign, publish-walletconnect-pay]
     runs-on: ubuntu-latest
+    outputs:
+      package_version: ${{ steps.get_version.outputs.version }}
+      published: ${{ steps.mark_published.outputs.published }}
     steps:
       - name: Check if reown_walletkit should be published
         if: github.event.inputs.walletkit == 'false'
@@ -552,6 +575,11 @@ jobs:
           chmod +x .github/scripts/wait_for_package.sh
           .github/scripts/wait_for_package.sh reown_walletkit ${{ steps.get_version.outputs.version }}
 
+      - name: Mark reown_walletkit as published
+        id: mark_published
+        if: github.event.inputs.walletkit == 'true'
+        run: echo "published=true" >> "$GITHUB_OUTPUT"
+
       - name: Post a message in a channel
         uses: slackapi/slack-github-action@v2.1.0
         if: github.event.inputs.walletkit == 'true'
@@ -567,6 +595,7 @@ jobs:
     runs-on: ubuntu-latest
     outputs:
       package_version: ${{ steps.get_version.outputs.version }}
+      published: ${{ steps.mark_published.outputs.published }}
     steps:
       - name: Check if reown_yttrium should be published
         if: github.event.inputs.yttrium == 'false'
@@ -637,6 +666,11 @@ jobs:
           chmod +x .github/scripts/wait_for_package.sh
           .github/scripts/wait_for_package.sh reown_yttrium ${{ steps.get_version.outputs.version }}
 
+      - name: Mark reown_yttrium as published
+        id: mark_published
+        if: github.event.inputs.yttrium == 'true'
+        run: echo "published=true" >> "$GITHUB_OUTPUT"
+
       - name: Post a message in a channel
         uses: slackapi/slack-github-action@v2.1.0
         if: github.event.inputs.yttrium == 'true'
@@ -652,6 +686,7 @@ jobs:
     runs-on: ubuntu-latest
     outputs:
       package_version: ${{ steps.get_version.outputs.version }}
+      published: ${{ steps.mark_published.outputs.published }}
     steps:
       - name: Check if reown_cli should be published
         if: github.event.inputs.cli == 'false'
@@ -722,6 +757,11 @@ jobs:
           chmod +x .github/scripts/wait_for_package.sh
           .github/scripts/wait_for_package.sh reown_cli ${{ steps.get_version.outputs.version }}
 
+      - name: Mark reown_cli as published
+        id: mark_published
+        if: github.event.inputs.cli == 'true'
+        run: echo "published=true" >> "$GITHUB_OUTPUT"
+
       - name: Post a message in a channel
         uses: slackapi/slack-github-action@v2.1.0
         if: github.event.inputs.cli == 'true'
@@ -737,6 +777,7 @@ jobs:
     runs-on: ubuntu-latest
     outputs:
       package_version: ${{ steps.get_version.outputs.version }}
+      published: ${{ steps.mark_published.outputs.published }}
     steps:
       - name: Check if pos_client should be published
         if: github.event.inputs.pos == 'false'
@@ -807,6 +848,11 @@ jobs:
           chmod +x .github/scripts/wait_for_package.sh
           .github/scripts/wait_for_package.sh pos_client ${{ steps.get_version.outputs.version }}
 
+      - name: Mark pos_client as published
+        id: mark_published
+        if: github.event.inputs.pos == 'true'
+        run: echo "published=true" >> "$GITHUB_OUTPUT"
+
       - name: Post a message in a channel
         uses: slackapi/slack-github-action@v2.1.0
         if: github.event.inputs.pos == 'true'
@@ -822,6 +868,7 @@ jobs:
     runs-on: ubuntu-latest
     outputs:
       package_version: ${{ steps.get_version.outputs.version }}
+      published: ${{ steps.mark_published.outputs.published }}
     steps:
       - name: Check if walletconnect_pay should be published
         if: github.event.inputs.walletconnect_pay == 'false'
@@ -893,6 +940,11 @@ jobs:
           chmod +x .github/scripts/wait_for_package.sh
           .github/scripts/wait_for_package.sh walletconnect_pay ${{ steps.get_version.outputs.version }}
 
+      - name: Mark walletconnect_pay as published
+        id: mark_published
+        if: github.event.inputs.walletconnect_pay == 'true'
+        run: echo "published=true" >> "$GITHUB_OUTPUT"
+
       - name: Post a message in a channel
         uses: slackapi/slack-github-action@v2.1.0
         if: github.event.inputs.walletconnect_pay == 'true'
@@ -924,6 +976,72 @@ jobs:
         with:
           ref: ${{ needs.create-branch.outputs.branch_name }}
           fetch-depth: 0
+
+      # Build a machine-readable manifest of the versions that were CONFIRMED
+      # published to pub.dev (published output set right after the availability
+      # wait). This is consumed by the tag-releases workflow after the PR merges.
+      # Committing it also guarantees the branch is ahead of develop, so a PR is
+      # opened even for an independent-package publish that changed no deps.
+      - name: Build release manifest
+        id: manifest
+        env:
+          RUN_NUMBER: ${{ github.run_number }}
+          RUN_ID: ${{ github.run_id }}
+        run: |
+          set -euo pipefail
+
+          # name|published|version for every package job
+          ENTRIES=(
+            "reown_core|${{ needs.publish-core.outputs.published }}|${{ needs.publish-core.outputs.package_version }}"
+            "reown_sign|${{ needs.publish-sign.outputs.published }}|${{ needs.publish-sign.outputs.package_version }}"
+            "reown_appkit|${{ needs.publish-appkit.outputs.published }}|${{ needs.publish-appkit.outputs.package_version }}"
+            "reown_walletkit|${{ needs.publish-walletkit.outputs.published }}|${{ needs.publish-walletkit.outputs.package_version }}"
+            "reown_yttrium|${{ needs.publish-yttrium.outputs.published }}|${{ needs.publish-yttrium.outputs.package_version }}"
+            "reown_cli|${{ needs.publish-cli.outputs.published }}|${{ needs.publish-cli.outputs.package_version }}"
+            "pos_client|${{ needs.publish-pos.outputs.published }}|${{ needs.publish-pos.outputs.package_version }}"
+            "walletconnect_pay|${{ needs.publish-walletconnect-pay.outputs.published }}|${{ needs.publish-walletconnect-pay.outputs.package_version }}"
+          )
+
+          PKGS_JSON="[]"
+          PKG_LIST=""
+          for e in "${ENTRIES[@]}"; do
+            IFS='|' read -r name published version <<<"$e"
+            if [[ "$published" == "true" && -n "$version" ]]; then
+              PKGS_JSON="$(jq -c --arg n "$name" --arg v "$version" \
+                '. + [{name:$n, version:$v}]' <<<"$PKGS_JSON")"
+              PKG_LIST="${PKG_LIST}- ${name} ${version}"$'\n'
+            fi
+          done
+
+          COUNT="$(jq 'length' <<<"$PKGS_JSON")"
+          if [[ "$COUNT" -eq 0 ]]; then
+            echo "No packages were confirmed published; no manifest will be written."
+            echo "has_manifest=false" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          mkdir -p .github/release-manifests
+          MF=".github/release-manifests/publish_workflow_${RUN_NUMBER}.json"
+          jq -n \
+            --argjson rid "$RUN_ID" \
+            --argjson rn "$RUN_NUMBER" \
+            --argjson pkgs "$(jq 'sort_by(.name)' <<<"$PKGS_JSON")" \
+            '{schema_version: 1, workflow_run_id: $rid, workflow_run_number: $rn, packages: $pkgs}' \
+            > "$MF"
+          echo "Wrote $MF:"
+          cat "$MF"
+
+          git config --global user.name 'github-actions[bot]'
+          git config --global user.email 'github-actions[bot]@users.noreply.github.com'
+          git add "$MF"
+          git commit -m "ci(release): add publish manifest for run ${RUN_NUMBER} [skip ci]"
+
+          echo "has_manifest=true" >> "$GITHUB_OUTPUT"
+          {
+            echo "pkg_list<<PKG_EOF"
+            printf '%s' "$PKG_LIST"
+            echo "PKG_EOF"
+          } >> "$GITHUB_OUTPUT"
 
       - name: Check if there are any changes to commit
         id: check_changes
@@ -960,18 +1078,13 @@ jobs:
             This PR contains package dependency updates and releases from the automated publishing workflow.
 
             ## Packages Published
-            ${{ github.event.inputs.core == 'true' && '- reown_core' || '' }}
-            ${{ github.event.inputs.sign == 'true' && '- reown_sign' || '' }}
-            ${{ github.event.inputs.appkit == 'true' && '- reown_appkit' || '' }}
-            ${{ github.event.inputs.walletkit == 'true' && '- reown_walletkit' || '' }}
-            ${{ github.event.inputs.yttrium == 'true' && '- reown_yttrium' || '' }}
-            ${{ github.event.inputs.cli == 'true' && '- reown_cli' || '' }}
-            ${{ github.event.inputs.pos == 'true' && '- pos_client' || '' }}
-            ${{ github.event.inputs.walletconnect_pay == 'true' && '- walletconnect_pay' || '' }}
+            ${{ steps.manifest.outputs.pkg_list }}
 
             ## Changes
             - Updated package dependencies to latest published versions
-            - All packages have been successfully published to pub.dev
+            - Only versions confirmed available on pub.dev are listed above
+            - A release manifest was committed under `.github/release-manifests/`;
+              GitHub Releases are created from it after this PR merges
 
             This PR was automatically created by the GitHub Actions workflow.
 

--- a/.github/workflows/publish-packages.yml
+++ b/.github/workflows/publish-packages.yml
@@ -90,8 +90,8 @@ jobs:
           BRANCH_NAME="publish_workflow_${{ github.run_number }}"
           echo "branch_name=$BRANCH_NAME" >> $GITHUB_OUTPUT
 
-          git config --global user.name 'github-actions[bot]'
-          git config --global user.email 'github-actions[bot]@users.noreply.github.com'
+          git config user.name 'github-actions[bot]'
+          git config user.email 'github-actions[bot]@users.noreply.github.com'
 
           git checkout -b $BRANCH_NAME
           git push -u origin $BRANCH_NAME
@@ -104,7 +104,7 @@ jobs:
     runs-on: ubuntu-latest
     outputs:
       package_version: ${{ steps.get_version.outputs.version }}
-      published: ${{ steps.mark_published.outputs.published }}
+      published: ${{ steps.mark_published.outputs.published || 'false' }}
     steps:
       - name: Check if reown_core should be published
         if: github.event.inputs.core == 'false'
@@ -140,8 +140,8 @@ jobs:
       - name: Commit and push pubspec.yaml changes for reown_core
         if: github.event.inputs.core == 'true' && github.event.inputs.yttrium == 'true' && needs.publish-yttrium.outputs.package_version != ''
         run: |
-          git config --global user.name 'github-actions[bot]'
-          git config --global user.email 'github-actions[bot]@users.noreply.github.com'
+          git config user.name 'github-actions[bot]'
+          git config user.email 'github-actions[bot]@users.noreply.github.com'
           cd packages/reown_core
           # Check if there are changes to commit to prevent empty commits
           if [[ -n $(git status -s pubspec.yaml) ]]; then
@@ -225,7 +225,7 @@ jobs:
     runs-on: ubuntu-latest
     outputs:
       package_version: ${{ steps.get_version.outputs.version }}
-      published: ${{ steps.mark_published.outputs.published }}
+      published: ${{ steps.mark_published.outputs.published || 'false' }}
     steps:
       - name: Check if reown_sign should be published
         if: github.event.inputs.sign == 'false'
@@ -261,8 +261,8 @@ jobs:
       - name: Commit and push pubspec.yaml changes for reown_sign
         if: github.event.inputs.sign == 'true' && github.event.inputs.core == 'true' && needs.publish-core.outputs.package_version != ''
         run: |
-          git config --global user.name 'github-actions[bot]'
-          git config --global user.email 'github-actions[bot]@users.noreply.github.com'
+          git config user.name 'github-actions[bot]'
+          git config user.email 'github-actions[bot]@users.noreply.github.com'
           cd packages/reown_sign
           # Check if there are changes to commit to prevent empty commits
           if [[ -n $(git status -s pubspec.yaml) ]]; then
@@ -346,7 +346,7 @@ jobs:
     runs-on: ubuntu-latest
     outputs:
       package_version: ${{ steps.get_version.outputs.version }}
-      published: ${{ steps.mark_published.outputs.published }}
+      published: ${{ steps.mark_published.outputs.published || 'false' }}
     steps:
       - name: Check if reown_appkit should be published
         if: github.event.inputs.appkit == 'false'
@@ -393,8 +393,8 @@ jobs:
       - name: Commit and push pubspec.yaml changes for reown_appkit
         if: github.event.inputs.appkit == 'true' && ((github.event.inputs.core == 'true' && needs.publish-core.outputs.package_version != '') || (github.event.inputs.sign == 'true' && needs.publish-sign.outputs.package_version != ''))
         run: |
-          git config --global user.name 'github-actions[bot]'
-          git config --global user.email 'github-actions[bot]@users.noreply.github.com'
+          git config user.name 'github-actions[bot]'
+          git config user.email 'github-actions[bot]@users.noreply.github.com'
           cd packages/reown_appkit
           # Check if there are changes to commit to prevent empty commits
           if [[ -n $(git status -s pubspec.yaml) ]]; then
@@ -478,7 +478,7 @@ jobs:
     runs-on: ubuntu-latest
     outputs:
       package_version: ${{ steps.get_version.outputs.version }}
-      published: ${{ steps.mark_published.outputs.published }}
+      published: ${{ steps.mark_published.outputs.published || 'false' }}
     steps:
       - name: Check if reown_walletkit should be published
         if: github.event.inputs.walletkit == 'false'
@@ -528,8 +528,8 @@ jobs:
       - name: Commit and push pubspec.yaml changes for reown_walletkit
         if: github.event.inputs.walletkit == 'true' && ((github.event.inputs.core == 'true' && needs.publish-core.outputs.package_version != '') || (github.event.inputs.sign == 'true' && needs.publish-sign.outputs.package_version != '') || (github.event.inputs.walletconnect_pay == 'true' && needs.publish-walletconnect-pay.outputs.package_version != ''))
         run: |
-          git config --global user.name 'github-actions[bot]'
-          git config --global user.email 'github-actions[bot]@users.noreply.github.com'
+          git config user.name 'github-actions[bot]'
+          git config user.email 'github-actions[bot]@users.noreply.github.com'
           cd packages/reown_walletkit
           # Check if there are changes to commit to prevent empty commits
           if [[ -n $(git status -s pubspec.yaml) ]]; then
@@ -613,7 +613,7 @@ jobs:
     runs-on: ubuntu-latest
     outputs:
       package_version: ${{ steps.get_version.outputs.version }}
-      published: ${{ steps.mark_published.outputs.published }}
+      published: ${{ steps.mark_published.outputs.published || 'false' }}
     steps:
       - name: Check if reown_yttrium should be published
         if: github.event.inputs.yttrium == 'false'
@@ -711,7 +711,7 @@ jobs:
     runs-on: ubuntu-latest
     outputs:
       package_version: ${{ steps.get_version.outputs.version }}
-      published: ${{ steps.mark_published.outputs.published }}
+      published: ${{ steps.mark_published.outputs.published || 'false' }}
     steps:
       - name: Check if reown_cli should be published
         if: github.event.inputs.cli == 'false'
@@ -809,7 +809,7 @@ jobs:
     runs-on: ubuntu-latest
     outputs:
       package_version: ${{ steps.get_version.outputs.version }}
-      published: ${{ steps.mark_published.outputs.published }}
+      published: ${{ steps.mark_published.outputs.published || 'false' }}
     steps:
       - name: Check if pos_client should be published
         if: github.event.inputs.pos == 'false'
@@ -907,7 +907,7 @@ jobs:
     runs-on: ubuntu-latest
     outputs:
       package_version: ${{ steps.get_version.outputs.version }}
-      published: ${{ steps.mark_published.outputs.published }}
+      published: ${{ steps.mark_published.outputs.published || 'false' }}
     steps:
       - name: Check if walletconnect_pay should be published
         if: github.event.inputs.walletconnect_pay == 'false'
@@ -1087,8 +1087,8 @@ jobs:
           echo "Wrote $MF:"
           cat "$MF"
 
-          git config --global user.name 'github-actions[bot]'
-          git config --global user.email 'github-actions[bot]@users.noreply.github.com'
+          git config user.name 'github-actions[bot]'
+          git config user.email 'github-actions[bot]@users.noreply.github.com'
           git add "$MF"
           git commit -m "ci(release): add publish manifest for run ${RUN_NUMBER} [skip ci]"
 
@@ -1116,8 +1116,8 @@ jobs:
       - name: Push all changes
         if: steps.check_changes.outputs.has_changes == 'true'
         run: |
-          git config --global user.name 'github-actions[bot]'
-          git config --global user.email 'github-actions[bot]@users.noreply.github.com'
+          git config user.name 'github-actions[bot]'
+          git config user.email 'github-actions[bot]@users.noreply.github.com'
           git push origin ${{ needs.create-branch.outputs.branch_name }}
 
       - name: Create Pull Request

--- a/.github/workflows/tag-releases.yml
+++ b/.github/workflows/tag-releases.yml
@@ -43,7 +43,6 @@ jobs:
           github.event.pull_request.merged == true &&
           github.event.pull_request.head.repo.full_name == github.repository &&
           github.event.pull_request.user.login == 'github-actions[bot]' &&
-          github.event.pull_request.title == 'ci: Package dependency updates and releases' &&
           startsWith(github.event.pull_request.head.ref, 'publish_workflow_')
         )
       }}

--- a/.github/workflows/tag-releases.yml
+++ b/.github/workflows/tag-releases.yml
@@ -19,6 +19,11 @@ on:
     types: [closed]
     branches: [develop]
   workflow_dispatch:
+    inputs:
+      target_sha:
+        description: "Commit SHA to tag/target (defaults to the checked-out HEAD). Set this when backfilling so releases point at the commit that actually shipped, not a moved develop HEAD."
+        required: false
+        default: ""
 
 concurrency:
   group: tag-releases
@@ -50,7 +55,9 @@ jobs:
           ref: >-
             ${{ github.event_name == 'pull_request'
                 && github.event.pull_request.merge_commit_sha
-                || github.sha }}
+                || (github.event.inputs.target_sha != ''
+                    && github.event.inputs.target_sha
+                    || github.sha) }}
 
       - name: Fetch tags
         run: git fetch --tags --force

--- a/.github/workflows/tag-releases.yml
+++ b/.github/workflows/tag-releases.yml
@@ -21,7 +21,7 @@ on:
   workflow_dispatch:
     inputs:
       target_sha:
-        description: "Commit SHA to tag/target (defaults to the checked-out HEAD). Set this when backfilling so releases point at the commit that actually shipped, not a moved develop HEAD."
+        description: "Commit to tag. Leave blank to use the selected branch's HEAD; for a backfill, enter the commit containing the published package."
         required: false
         default: ""
 
@@ -48,25 +48,33 @@ jobs:
         )
       }}
     steps:
-      - name: Checkout target commit
+      - name: Checkout workflow branch
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
           ref: >-
             ${{ github.event_name == 'pull_request'
                 && github.event.pull_request.merge_commit_sha
-                || (github.event.inputs.target_sha != ''
-                    && github.event.inputs.target_sha
-                    || github.sha) }}
+                || github.ref }}
 
       - name: Fetch tags
         run: git fetch --tags --force
 
       - name: Resolve mode and target SHA
         id: cfg
+        env:
+          TARGET_SHA_INPUT: ${{ github.event.inputs.target_sha }}
         run: |
           set -euo pipefail
-          SHA="$(git rev-parse HEAD)"
+          if [[ -n "$TARGET_SHA_INPUT" ]]; then
+            if [[ ! "$TARGET_SHA_INPUT" =~ ^[0-9a-fA-F]{7,40}$ ]]; then
+              echo "target_sha must be a hexadecimal commit SHA: $TARGET_SHA_INPUT" >&2
+              exit 1
+            fi
+            SHA="$(git rev-parse "$TARGET_SHA_INPUT^{commit}")"
+          else
+            SHA="$(git rev-parse HEAD)"
+          fi
           echo "sha=$SHA" >> "$GITHUB_OUTPUT"
           if [[ "${{ github.event_name }}" == "workflow_dispatch" ]]; then
             echo "mode=manual" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/tag-releases.yml
+++ b/.github/workflows/tag-releases.yml
@@ -1,0 +1,139 @@
+name: Tag Releases
+
+# Creates a GitHub Release ("<package_name>-v<version>") for every package version
+# confirmed published to pub.dev, targeting the develop mainline commit.
+#
+# Normal path: the automated release PR (from publish-packages.yml) merges into
+# develop carrying a release manifest; this workflow reads that manifest, verifies
+# each version on pub.dev, and creates the releases at the merge commit. Manifests
+# are kept under .github/release-manifests/ as a permanent per-run audit trail.
+#
+# Manual path: workflow_dispatch scans the current pubspec versions and backfills
+# any that are on pub.dev but not yet released.
+#
+# NOTE: pull_request workflows run the file version on the BASE branch, so this
+# only applies to release PRs merged AFTER this file lands on develop.
+
+on:
+  pull_request:
+    types: [closed]
+    branches: [develop]
+  workflow_dispatch:
+
+concurrency:
+  group: tag-releases
+  cancel-in-progress: false
+
+permissions:
+  contents: write
+
+jobs:
+  create-releases:
+    name: Create GitHub Releases
+    runs-on: ubuntu-latest
+    if: >-
+      ${{
+        github.event_name == 'workflow_dispatch' ||
+        (
+          github.event.pull_request.merged == true &&
+          github.event.pull_request.head.repo.full_name == github.repository &&
+          github.event.pull_request.user.login == 'github-actions[bot]' &&
+          github.event.pull_request.title == 'ci: Package dependency updates and releases' &&
+          startsWith(github.event.pull_request.head.ref, 'publish_workflow_')
+        )
+      }}
+    steps:
+      - name: Checkout target commit
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          ref: >-
+            ${{ github.event_name == 'pull_request'
+                && github.event.pull_request.merge_commit_sha
+                || github.sha }}
+
+      - name: Fetch tags
+        run: git fetch --tags --force
+
+      - name: Resolve mode and target SHA
+        id: cfg
+        run: |
+          set -euo pipefail
+          SHA="$(git rev-parse HEAD)"
+          echo "sha=$SHA" >> "$GITHUB_OUTPUT"
+          if [[ "${{ github.event_name }}" == "workflow_dispatch" ]]; then
+            echo "mode=manual" >> "$GITHUB_OUTPUT"
+          else
+            echo "mode=manifest" >> "$GITHUB_OUTPUT"
+          fi
+          echo "dry_run=${{ vars.TAG_RELEASES_DRY_RUN || 'false' }}" >> "$GITHUB_OUTPUT"
+
+      - name: Validate release branch and locate manifest
+        id: manifest
+        if: steps.cfg.outputs.mode == 'manifest'
+        run: |
+          set -euo pipefail
+          BRANCH="${{ github.event.pull_request.head.ref }}"
+          # startsWith in the job `if` is intentionally loose; enforce the exact
+          # shape here so e.g. `publish_workflow_change` cannot slip through.
+          if [[ ! "$BRANCH" =~ ^publish_workflow_[0-9]+$ ]]; then
+            echo "Branch '$BRANCH' does not match ^publish_workflow_[0-9]+\$; refusing." >&2
+            exit 1
+          fi
+          RUN_NUMBER="${BRANCH#publish_workflow_}"
+          MF=".github/release-manifests/${BRANCH}.json"
+          if [[ ! -f "$MF" ]]; then
+            echo "No manifest at $MF in the merged tree; nothing to release."
+            echo "found=false" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          MF_RUN="$(jq -r '.workflow_run_number' "$MF")"
+          if [[ "$MF_RUN" != "$RUN_NUMBER" ]]; then
+            echo "Manifest run number ($MF_RUN) != branch run number ($RUN_NUMBER)." >&2
+            exit 1
+          fi
+          echo "path=$MF" >> "$GITHUB_OUTPUT"
+          echo "found=true" >> "$GITHUB_OUTPUT"
+
+      - name: Create releases
+        if: steps.cfg.outputs.mode == 'manual' || steps.manifest.outputs.found == 'true'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          MODE: ${{ steps.cfg.outputs.mode }}
+          TARGET_SHA: ${{ steps.cfg.outputs.sha }}
+          MANIFEST_PATH: ${{ steps.manifest.outputs.path }}
+          DRY_RUN: ${{ steps.cfg.outputs.dry_run }}
+          SUMMARY_FILE: ${{ github.workspace }}/.release-summary.txt
+        run: |
+          chmod +x .github/scripts/create_github_releases.sh
+          .github/scripts/create_github_releases.sh
+
+      - name: Build Slack summary
+        id: slack
+        if: steps.cfg.outputs.mode == 'manual' || steps.manifest.outputs.found == 'true'
+        run: |
+          set -euo pipefail
+          SUMMARY_FILE="${{ github.workspace }}/.release-summary.txt"
+          if [[ -s "$SUMMARY_FILE" ]]; then
+            COUNT="$(wc -l < "$SUMMARY_FILE" | tr -d ' ')"
+            LINES="$(sed 's#^#• https://github.com/${{ github.repository }}/releases/tag/#' "$SUMMARY_FILE")"
+            {
+              echo "text<<SLACK_EOF"
+              echo "*New GitHub Releases created* ($COUNT)"
+              echo "$LINES"
+              echo "SLACK_EOF"
+            } >> "$GITHUB_OUTPUT"
+            echo "have=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "No releases created; skipping Slack summary."
+            echo "have=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Post Slack summary
+        if: steps.slack.outputs.have == 'true'
+        uses: slackapi/slack-github-action@v2.1.0
+        with:
+          webhook: ${{ secrets.SLACK_WEBHOOK_URL }}
+          webhook-type: incoming-webhook
+          payload: |
+            text: ${{ toJSON(steps.slack.outputs.text) }}


### PR DESCRIPTION
## Summary

Publishing to pub.dev currently leaves no link back to the source commit, and
the repository's existing tags are hand-made, inconsistently named, and cover
only a small number of releases.

This PR adds automatic, per-package GitHub Releases named
`<package>-v<version>` (for example, `reown_core-v1.4.0`). Confirmed pub.dev
publishes are recorded in a manifest, carried through the automated release PR,
and converted into GitHub Releases after the PR merges.

## Release flow

1. `publish-packages.yml` publishes the selected packages and waits for each
   exact version to become available on pub.dev.
2. Each successful publication sets a `published=true` job output before the
   Slack notification. Slack failures cannot prevent manifest creation.
3. The workflow commits a manifest under
   `.github/release-manifests/publish_workflow_<run>.json` and opens the release
   PR. This also works for independent packages whose dependencies do not
   change.
4. After the automated release PR merges into `develop`, `tag-releases.yml`
   validates the manifest, re-checks pub.dev, and creates one GitHub Release per
   package. Normal releases target the merge commit on `develop`.

## Manual backfill

`tag-releases.yml` also supports `workflow_dispatch` for backfills.

- The workflow runs from the selected branch, so the branch must contain the
  release script. This allows testing the workflow from `release-improvements`
  before this PR is merged.
- Leave `target_sha` blank to point releases at the selected branch's HEAD.
- For a historical backfill, enter the commit containing the published package;
  `target_sha` controls the tag/release target independently of the workflow
  branch checkout.
- Set the repository variable `TAG_RELEASES_DRY_RUN=true` to verify pub.dev
  versions, existing tags, and intended `gh release create` commands without
  creating anything. Remove the variable or set it to `false` to create the
  releases.

## Release notes and tag safety

- The first release for a package, when no prior `<package>-v*` tag exists, uses
  a short explicit initial-release note. It does not ask GitHub to generate
  notes from the repository-wide release history.
- Later releases use GitHub-generated notes starting at the previous tag for
  that same package.
- Existing legacy tags are left untouched, and each package has its own tag
  history. Releases are created with `--latest=false` so independently-versioned
  packages do not compete for one repository-wide Latest release.
- The helper handles existing release/tag combinations safely and supports
  `DRY_RUN`.

## Testing

- Both workflows YAML-parse and the helper passes `bash -n`.
- The workflow has been exercised in GitHub Actions in dry-run mode against live
  pub.dev data.
- `reown_core-v1.4.0` was also created successfully as a real test release with
  a short explicit note and the expected target commit.

## Rollout

`workflow_dispatch` requires the workflow file to exist on the default branch.
After this PR lands on `develop`, manual backfills can be run directly from the
Actions UI. The normal merged-release-PR trigger applies to release PRs merged
after this workflow is present on `develop`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
