### PR TITLE
ci(publish): harden secret handling (token in push URL, pub creds perms)

### DIFF
--- a/.github/workflows/publish-packages.yml
+++ b/.github/workflows/publish-packages.yml
@@ -86,8 +86,6 @@ jobs:
 
       - name: Create release branch
         id: create_branch
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           BRANCH_NAME="publish_workflow_${{ github.run_number }}"
           echo "branch_name=$BRANCH_NAME" >> $GITHUB_OUTPUT
@@ -96,7 +94,7 @@ jobs:
           git config --global user.email 'github-actions[bot]@users.noreply.github.com'
 
           git checkout -b $BRANCH_NAME
-          git push -u https://x-access-token:${GITHUB_TOKEN}@github.com/${{ github.repository }} $BRANCH_NAME
+          git push -u origin $BRANCH_NAME
 
           echo "Created and pushed branch: $BRANCH_NAME"
 
@@ -140,8 +138,6 @@ jobs:
 
       - name: Commit and push pubspec.yaml changes for reown_core
         if: github.event.inputs.core == 'true' && github.event.inputs.yttrium == 'true' && needs.publish-yttrium.outputs.package_version != ''
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           git config --global user.name 'github-actions[bot]'
           git config --global user.email 'github-actions[bot]@users.noreply.github.com'
@@ -150,7 +146,7 @@ jobs:
           if [[ -n $(git status -s pubspec.yaml) ]]; then
             git add pubspec.yaml
             git commit -m "ci(reown_core): Update reown_yttrium to ^${{ needs.publish-yttrium.outputs.package_version }} [skip ci]"
-            git push https://x-access-token:${GITHUB_TOKEN}@github.com/${{ github.repository }} ${{ needs.create-branch.outputs.branch_name }}
+            git push origin ${{ needs.create-branch.outputs.branch_name }}
           else
             echo "No changes to commit in reown_core/pubspec.yaml"
           fi
@@ -166,6 +162,7 @@ jobs:
         run: |
           mkdir -p $HOME/.config/dart
           echo '${{ secrets.PUB_CREDENTIALS }}' > $HOME/.config/dart/pub-credentials.json
+          chmod 600 $HOME/.config/dart/pub-credentials.json
 
       - name: Run generate_files.sh for reown_core
         if: github.event.inputs.core == 'true'
@@ -194,6 +191,10 @@ jobs:
         if: github.event.inputs.core == 'true'
         working-directory: packages/reown_core
         run: flutter pub publish --force
+
+      - name: Remove pub.dev credentials
+        if: always() && github.event.inputs.core == 'true'
+        run: rm -f $HOME/.config/dart/pub-credentials.json
 
       - name: Wait for reown_core to be available on pub.dev
         if: github.event.inputs.core == 'true'
@@ -250,8 +251,6 @@ jobs:
 
       - name: Commit and push pubspec.yaml changes for reown_sign
         if: github.event.inputs.sign == 'true' && github.event.inputs.core == 'true' && needs.publish-core.outputs.package_version != ''
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           git config --global user.name 'github-actions[bot]'
           git config --global user.email 'github-actions[bot]@users.noreply.github.com'
@@ -260,7 +259,7 @@ jobs:
           if [[ -n $(git status -s pubspec.yaml) ]]; then
             git add pubspec.yaml
             git commit -m "ci(reown_sign): Update reown_core to ^${{ needs.publish-core.outputs.package_version }} [skip ci]"
-            git push https://x-access-token:${GITHUB_TOKEN}@github.com/${{ github.repository }} ${{ needs.create-branch.outputs.branch_name }}
+            git push origin ${{ needs.create-branch.outputs.branch_name }}
           else
             echo "No changes to commit in reown_sign/pubspec.yaml"
           fi
@@ -276,6 +275,7 @@ jobs:
         run: |
           mkdir -p $HOME/.config/dart
           echo '${{ secrets.PUB_CREDENTIALS }}' > $HOME/.config/dart/pub-credentials.json
+          chmod 600 $HOME/.config/dart/pub-credentials.json
 
       - name: Run generate_files.sh for reown_sign
         if: github.event.inputs.sign == 'true'
@@ -304,6 +304,10 @@ jobs:
         if: github.event.inputs.sign == 'true'
         working-directory: packages/reown_sign
         run: flutter pub publish --force
+
+      - name: Remove pub.dev credentials
+        if: always() && github.event.inputs.sign == 'true'
+        run: rm -f $HOME/.config/dart/pub-credentials.json
 
       - name: Wait for reown_sign to be available on pub.dev
         if: github.event.inputs.sign == 'true'
@@ -369,8 +373,6 @@ jobs:
 
       - name: Commit and push pubspec.yaml changes for reown_appkit
         if: github.event.inputs.appkit == 'true' && ((github.event.inputs.core == 'true' && needs.publish-core.outputs.package_version != '') || (github.event.inputs.sign == 'true' && needs.publish-sign.outputs.package_version != ''))
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           git config --global user.name 'github-actions[bot]'
           git config --global user.email 'github-actions[bot]@users.noreply.github.com'
@@ -379,7 +381,7 @@ jobs:
           if [[ -n $(git status -s pubspec.yaml) ]]; then
             git add pubspec.yaml
             git commit -m "ci(reown_appkit): Update core/sign dependencies [skip ci]"
-            git push https://x-access-token:${GITHUB_TOKEN}@github.com/${{ github.repository }} ${{ needs.create-branch.outputs.branch_name }}
+            git push origin ${{ needs.create-branch.outputs.branch_name }}
           else
             echo "No changes to commit in reown_appkit/pubspec.yaml"
           fi
@@ -395,6 +397,7 @@ jobs:
         run: |
           mkdir -p $HOME/.config/dart
           echo '${{ secrets.PUB_CREDENTIALS }}' > $HOME/.config/dart/pub-credentials.json
+          chmod 600 $HOME/.config/dart/pub-credentials.json
 
       - name: Run generate_files.sh for reown_appkit
         if: github.event.inputs.appkit == 'true'
@@ -423,6 +426,10 @@ jobs:
         if: github.event.inputs.appkit == 'true'
         working-directory: packages/reown_appkit
         run: flutter pub publish --force
+
+      - name: Remove pub.dev credentials
+        if: always() && github.event.inputs.appkit == 'true'
+        run: rm -f $HOME/.config/dart/pub-credentials.json
 
       - name: Wait for reown_appkit to be available on pub.dev
         if: github.event.inputs.appkit == 'true'
@@ -491,8 +498,6 @@ jobs:
 
       - name: Commit and push pubspec.yaml changes for reown_walletkit
         if: github.event.inputs.walletkit == 'true' && ((github.event.inputs.core == 'true' && needs.publish-core.outputs.package_version != '') || (github.event.inputs.sign == 'true' && needs.publish-sign.outputs.package_version != '') || (github.event.inputs.walletconnect_pay == 'true' && needs.publish-walletconnect-pay.outputs.package_version != ''))
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           git config --global user.name 'github-actions[bot]'
           git config --global user.email 'github-actions[bot]@users.noreply.github.com'
@@ -501,7 +506,7 @@ jobs:
           if [[ -n $(git status -s pubspec.yaml) ]]; then
             git add pubspec.yaml
             git commit -m "ci(reown_walletkit): Update core/sign/walletconnect_pay dependencies [skip ci]"
-            git push https://x-access-token:${GITHUB_TOKEN}@github.com/${{ github.repository }} ${{ needs.create-branch.outputs.branch_name }}
+            git push origin ${{ needs.create-branch.outputs.branch_name }}
           else
             echo "No changes to commit in reown_walletkit/pubspec.yaml"
           fi
@@ -517,6 +522,7 @@ jobs:
         run: |
           mkdir -p $HOME/.config/dart
           echo '${{ secrets.PUB_CREDENTIALS }}' > $HOME/.config/dart/pub-credentials.json
+          chmod 600 $HOME/.config/dart/pub-credentials.json
 
       - name: Run generate_files.sh for reown_walletkit
         if: github.event.inputs.walletkit == 'true'
@@ -545,6 +551,10 @@ jobs:
         if: github.event.inputs.walletkit == 'true'
         working-directory: packages/reown_walletkit
         run: flutter pub publish --force
+
+      - name: Remove pub.dev credentials
+        if: always() && github.event.inputs.walletkit == 'true'
+        run: rm -f $HOME/.config/dart/pub-credentials.json
 
       - name: Wait for reown_walletkit to be available on pub.dev
         if: github.event.inputs.walletkit == 'true'
@@ -602,6 +612,7 @@ jobs:
         run: |
           mkdir -p $HOME/.config/dart
           echo '${{ secrets.PUB_CREDENTIALS }}' > $HOME/.config/dart/pub-credentials.json
+          chmod 600 $HOME/.config/dart/pub-credentials.json
 
       - name: Run generate_files.sh for reown_yttrium
         if: github.event.inputs.yttrium == 'true'
@@ -630,6 +641,10 @@ jobs:
         if: github.event.inputs.yttrium == 'true'
         working-directory: packages/reown_yttrium
         run: flutter pub publish --force
+
+      - name: Remove pub.dev credentials
+        if: always() && github.event.inputs.yttrium == 'true'
+        run: rm -f $HOME/.config/dart/pub-credentials.json
 
       - name: Wait for reown_yttrium to be available on pub.dev
         if: github.event.inputs.yttrium == 'true'
@@ -687,6 +702,7 @@ jobs:
         run: |
           mkdir -p $HOME/.config/dart
           echo '${{ secrets.PUB_CREDENTIALS }}' > $HOME/.config/dart/pub-credentials.json
+          chmod 600 $HOME/.config/dart/pub-credentials.json
 
       - name: Run generate_files.sh for reown_cli
         if: github.event.inputs.cli == 'true'
@@ -715,6 +731,10 @@ jobs:
         if: github.event.inputs.cli == 'true'
         working-directory: packages/reown_cli
         run: flutter pub publish --force
+
+      - name: Remove pub.dev credentials
+        if: always() && github.event.inputs.cli == 'true'
+        run: rm -f $HOME/.config/dart/pub-credentials.json
 
       - name: Wait for reown_cli to be available on pub.dev
         if: github.event.inputs.cli == 'true'
@@ -772,6 +792,7 @@ jobs:
         run: |
           mkdir -p $HOME/.config/dart
           echo '${{ secrets.PUB_CREDENTIALS }}' > $HOME/.config/dart/pub-credentials.json
+          chmod 600 $HOME/.config/dart/pub-credentials.json
 
       - name: Run generate_files.sh for pos_client
         if: github.event.inputs.pos == 'true'
@@ -800,6 +821,10 @@ jobs:
         if: github.event.inputs.pos == 'true'
         working-directory: packages/pos_client
         run: flutter pub publish --force
+
+      - name: Remove pub.dev credentials
+        if: always() && github.event.inputs.pos == 'true'
+        run: rm -f $HOME/.config/dart/pub-credentials.json
 
       - name: Wait for pos_client to be available on pub.dev
         if: github.event.inputs.pos == 'true'
@@ -857,6 +882,7 @@ jobs:
         run: |
           mkdir -p $HOME/.config/dart
           echo '${{ secrets.PUB_CREDENTIALS }}' > $HOME/.config/dart/pub-credentials.json
+          chmod 600 $HOME/.config/dart/pub-credentials.json
 
       - name: Run code generation for walletconnect_pay
         if: github.event.inputs.walletconnect_pay == 'true'
@@ -886,6 +912,10 @@ jobs:
         if: github.event.inputs.walletconnect_pay == 'true'
         working-directory: packages/walletconnect_pay
         run: flutter pub publish --force
+
+      - name: Remove pub.dev credentials
+        if: always() && github.event.inputs.walletconnect_pay == 'true'
+        run: rm -f $HOME/.config/dart/pub-credentials.json
 
       - name: Wait for walletconnect_pay to be available on pub.dev
         if: github.event.inputs.walletconnect_pay == 'true'
@@ -941,12 +971,10 @@ jobs:
 
       - name: Push all changes
         if: steps.check_changes.outputs.has_changes == 'true'
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           git config --global user.name 'github-actions[bot]'
           git config --global user.email 'github-actions[bot]@users.noreply.github.com'
-          git push https://x-access-token:${GITHUB_TOKEN}@github.com/${{ github.repository }} ${{ needs.create-branch.outputs.branch_name }}
+          git push origin ${{ needs.create-branch.outputs.branch_name }}
 
       - name: Create Pull Request
         if: steps.check_changes.outputs.has_changes == 'true'

--- a/.github/workflows/publish-packages.yml
+++ b/.github/workflows/publish-packages.yml
@@ -157,14 +157,6 @@ jobs:
         working-directory: packages/reown_core
         run: echo "version=$(yq e '.version' pubspec.yaml)" >> $GITHUB_OUTPUT
 
-      - name: Configure pub.dev credentials
-        if: github.event.inputs.core == 'true'
-        env:
-          PUB_CREDENTIALS: ${{ secrets.PUB_CREDENTIALS }}
-        run: |
-          mkdir -p $HOME/.config/dart
-          (umask 077; printf '%s' "$PUB_CREDENTIALS" > $HOME/.config/dart/pub-credentials.json)
-
       - name: Run generate_files.sh for reown_core
         if: github.event.inputs.core == 'true'
         working-directory: packages/reown_core
@@ -187,6 +179,14 @@ jobs:
           else
             echo "✅ No real errors, only warnings (e.g. missing CHANGELOG.md)"
           fi
+
+      - name: Configure pub.dev credentials
+        if: github.event.inputs.core == 'true'
+        env:
+          PUB_CREDENTIALS: ${{ secrets.PUB_CREDENTIALS }}
+        run: |
+          mkdir -p $HOME/.config/dart
+          (umask 077; printf '%s' "$PUB_CREDENTIALS" > $HOME/.config/dart/pub-credentials.json)
 
       - name: Publish reown_core to pub.dev
         if: github.event.inputs.core == 'true'
@@ -271,14 +271,6 @@ jobs:
         working-directory: packages/reown_sign
         run: echo "version=$(yq e '.version' pubspec.yaml)" >> $GITHUB_OUTPUT
 
-      - name: Configure pub.dev credentials
-        if: github.event.inputs.sign == 'true'
-        env:
-          PUB_CREDENTIALS: ${{ secrets.PUB_CREDENTIALS }}
-        run: |
-          mkdir -p $HOME/.config/dart
-          (umask 077; printf '%s' "$PUB_CREDENTIALS" > $HOME/.config/dart/pub-credentials.json)
-
       - name: Run generate_files.sh for reown_sign
         if: github.event.inputs.sign == 'true'
         working-directory: packages/reown_sign
@@ -301,6 +293,14 @@ jobs:
           else
             echo "✅ No real errors, only warnings (e.g. missing CHANGELOG.md)"
           fi
+
+      - name: Configure pub.dev credentials
+        if: github.event.inputs.sign == 'true'
+        env:
+          PUB_CREDENTIALS: ${{ secrets.PUB_CREDENTIALS }}
+        run: |
+          mkdir -p $HOME/.config/dart
+          (umask 077; printf '%s' "$PUB_CREDENTIALS" > $HOME/.config/dart/pub-credentials.json)
 
       - name: Publish reown_sign to pub.dev
         if: github.event.inputs.sign == 'true'
@@ -394,14 +394,6 @@ jobs:
         working-directory: packages/reown_appkit
         run: echo "version=$(yq e '.version' pubspec.yaml)" >> $GITHUB_OUTPUT
 
-      - name: Configure pub.dev credentials
-        if: github.event.inputs.appkit == 'true'
-        env:
-          PUB_CREDENTIALS: ${{ secrets.PUB_CREDENTIALS }}
-        run: |
-          mkdir -p $HOME/.config/dart
-          (umask 077; printf '%s' "$PUB_CREDENTIALS" > $HOME/.config/dart/pub-credentials.json)
-
       - name: Run generate_files.sh for reown_appkit
         if: github.event.inputs.appkit == 'true'
         working-directory: packages/reown_appkit
@@ -424,6 +416,14 @@ jobs:
           else
             echo "✅ No real errors, only warnings (e.g. missing CHANGELOG.md)"
           fi
+
+      - name: Configure pub.dev credentials
+        if: github.event.inputs.appkit == 'true'
+        env:
+          PUB_CREDENTIALS: ${{ secrets.PUB_CREDENTIALS }}
+        run: |
+          mkdir -p $HOME/.config/dart
+          (umask 077; printf '%s' "$PUB_CREDENTIALS" > $HOME/.config/dart/pub-credentials.json)
 
       - name: Publish reown_appkit to pub.dev
         if: github.event.inputs.appkit == 'true'
@@ -520,14 +520,6 @@ jobs:
         working-directory: packages/reown_walletkit
         run: echo "version=$(yq e '.version' pubspec.yaml)" >> $GITHUB_OUTPUT
 
-      - name: Configure pub.dev credentials
-        if: github.event.inputs.walletkit == 'true'
-        env:
-          PUB_CREDENTIALS: ${{ secrets.PUB_CREDENTIALS }}
-        run: |
-          mkdir -p $HOME/.config/dart
-          (umask 077; printf '%s' "$PUB_CREDENTIALS" > $HOME/.config/dart/pub-credentials.json)
-
       - name: Run generate_files.sh for reown_walletkit
         if: github.event.inputs.walletkit == 'true'
         working-directory: packages/reown_walletkit
@@ -550,6 +542,14 @@ jobs:
           else
             echo "✅ No real errors, only warnings (e.g. missing CHANGELOG.md)"
           fi
+
+      - name: Configure pub.dev credentials
+        if: github.event.inputs.walletkit == 'true'
+        env:
+          PUB_CREDENTIALS: ${{ secrets.PUB_CREDENTIALS }}
+        run: |
+          mkdir -p $HOME/.config/dart
+          (umask 077; printf '%s' "$PUB_CREDENTIALS" > $HOME/.config/dart/pub-credentials.json)
 
       - name: Publish reown_walletkit to pub.dev
         if: github.event.inputs.walletkit == 'true'
@@ -611,14 +611,6 @@ jobs:
         working-directory: packages/reown_yttrium
         run: echo "version=$(yq e '.version' pubspec.yaml)" >> $GITHUB_OUTPUT
 
-      - name: Configure pub.dev credentials
-        if: github.event.inputs.yttrium == 'true'
-        env:
-          PUB_CREDENTIALS: ${{ secrets.PUB_CREDENTIALS }}
-        run: |
-          mkdir -p $HOME/.config/dart
-          (umask 077; printf '%s' "$PUB_CREDENTIALS" > $HOME/.config/dart/pub-credentials.json)
-
       - name: Run generate_files.sh for reown_yttrium
         if: github.event.inputs.yttrium == 'true'
         working-directory: packages/reown_yttrium
@@ -641,6 +633,14 @@ jobs:
           else
             echo "✅ No real errors, only warnings (e.g. missing CHANGELOG.md)"
           fi
+
+      - name: Configure pub.dev credentials
+        if: github.event.inputs.yttrium == 'true'
+        env:
+          PUB_CREDENTIALS: ${{ secrets.PUB_CREDENTIALS }}
+        run: |
+          mkdir -p $HOME/.config/dart
+          (umask 077; printf '%s' "$PUB_CREDENTIALS" > $HOME/.config/dart/pub-credentials.json)
 
       - name: Publish reown_yttrium to pub.dev
         if: github.event.inputs.yttrium == 'true'
@@ -702,14 +702,6 @@ jobs:
         working-directory: packages/reown_cli
         run: echo "version=$(yq e '.version' pubspec.yaml)" >> $GITHUB_OUTPUT
 
-      - name: Configure pub.dev credentials
-        if: github.event.inputs.cli == 'true'
-        env:
-          PUB_CREDENTIALS: ${{ secrets.PUB_CREDENTIALS }}
-        run: |
-          mkdir -p $HOME/.config/dart
-          (umask 077; printf '%s' "$PUB_CREDENTIALS" > $HOME/.config/dart/pub-credentials.json)
-
       - name: Run generate_files.sh for reown_cli
         if: github.event.inputs.cli == 'true'
         working-directory: packages/reown_cli
@@ -732,6 +724,14 @@ jobs:
           else
             echo "✅ No real errors, only warnings (e.g. missing CHANGELOG.md)"
           fi
+
+      - name: Configure pub.dev credentials
+        if: github.event.inputs.cli == 'true'
+        env:
+          PUB_CREDENTIALS: ${{ secrets.PUB_CREDENTIALS }}
+        run: |
+          mkdir -p $HOME/.config/dart
+          (umask 077; printf '%s' "$PUB_CREDENTIALS" > $HOME/.config/dart/pub-credentials.json)
 
       - name: Publish reown_cli to pub.dev
         if: github.event.inputs.cli == 'true'
@@ -793,14 +793,6 @@ jobs:
         working-directory: packages/pos_client
         run: echo "version=$(yq e '.version' pubspec.yaml)" >> $GITHUB_OUTPUT
 
-      - name: Configure pub.dev credentials
-        if: github.event.inputs.pos == 'true'
-        env:
-          PUB_CREDENTIALS: ${{ secrets.PUB_CREDENTIALS }}
-        run: |
-          mkdir -p $HOME/.config/dart
-          (umask 077; printf '%s' "$PUB_CREDENTIALS" > $HOME/.config/dart/pub-credentials.json)
-
       - name: Run generate_files.sh for pos_client
         if: github.event.inputs.pos == 'true'
         working-directory: packages/pos_client
@@ -823,6 +815,14 @@ jobs:
           else
             echo "✅ No real errors, only warnings (e.g. missing CHANGELOG.md)"
           fi
+
+      - name: Configure pub.dev credentials
+        if: github.event.inputs.pos == 'true'
+        env:
+          PUB_CREDENTIALS: ${{ secrets.PUB_CREDENTIALS }}
+        run: |
+          mkdir -p $HOME/.config/dart
+          (umask 077; printf '%s' "$PUB_CREDENTIALS" > $HOME/.config/dart/pub-credentials.json)
 
       - name: Publish pos_client to pub.dev
         if: github.event.inputs.pos == 'true'
@@ -884,14 +884,6 @@ jobs:
         working-directory: packages/walletconnect_pay
         run: echo "version=$(yq e '.version' pubspec.yaml)" >> $GITHUB_OUTPUT
 
-      - name: Configure pub.dev credentials
-        if: github.event.inputs.walletconnect_pay == 'true'
-        env:
-          PUB_CREDENTIALS: ${{ secrets.PUB_CREDENTIALS }}
-        run: |
-          mkdir -p $HOME/.config/dart
-          (umask 077; printf '%s' "$PUB_CREDENTIALS" > $HOME/.config/dart/pub-credentials.json)
-
       - name: Run code generation for walletconnect_pay
         if: github.event.inputs.walletconnect_pay == 'true'
         working-directory: packages/walletconnect_pay
@@ -915,6 +907,14 @@ jobs:
           else
             echo "✅ No real errors, only warnings (e.g. missing CHANGELOG.md)"
           fi
+
+      - name: Configure pub.dev credentials
+        if: github.event.inputs.walletconnect_pay == 'true'
+        env:
+          PUB_CREDENTIALS: ${{ secrets.PUB_CREDENTIALS }}
+        run: |
+          mkdir -p $HOME/.config/dart
+          (umask 077; printf '%s' "$PUB_CREDENTIALS" > $HOME/.config/dart/pub-credentials.json)
 
       - name: Publish walletconnect_pay to pub.dev
         if: github.event.inputs.walletconnect_pay == 'true'

--- a/.github/workflows/publish-packages.yml
+++ b/.github/workflows/publish-packages.yml
@@ -159,9 +159,11 @@ jobs:
 
       - name: Configure pub.dev credentials
         if: github.event.inputs.core == 'true'
+        env:
+          PUB_CREDENTIALS: ${{ secrets.PUB_CREDENTIALS }}
         run: |
           mkdir -p $HOME/.config/dart
-          (umask 077 && echo '${{ secrets.PUB_CREDENTIALS }}' > $HOME/.config/dart/pub-credentials.json)
+          (umask 077; printf '%s' "$PUB_CREDENTIALS" > $HOME/.config/dart/pub-credentials.json)
 
       - name: Run generate_files.sh for reown_core
         if: github.event.inputs.core == 'true'
@@ -271,9 +273,11 @@ jobs:
 
       - name: Configure pub.dev credentials
         if: github.event.inputs.sign == 'true'
+        env:
+          PUB_CREDENTIALS: ${{ secrets.PUB_CREDENTIALS }}
         run: |
           mkdir -p $HOME/.config/dart
-          (umask 077 && echo '${{ secrets.PUB_CREDENTIALS }}' > $HOME/.config/dart/pub-credentials.json)
+          (umask 077; printf '%s' "$PUB_CREDENTIALS" > $HOME/.config/dart/pub-credentials.json)
 
       - name: Run generate_files.sh for reown_sign
         if: github.event.inputs.sign == 'true'
@@ -392,9 +396,11 @@ jobs:
 
       - name: Configure pub.dev credentials
         if: github.event.inputs.appkit == 'true'
+        env:
+          PUB_CREDENTIALS: ${{ secrets.PUB_CREDENTIALS }}
         run: |
           mkdir -p $HOME/.config/dart
-          (umask 077 && echo '${{ secrets.PUB_CREDENTIALS }}' > $HOME/.config/dart/pub-credentials.json)
+          (umask 077; printf '%s' "$PUB_CREDENTIALS" > $HOME/.config/dart/pub-credentials.json)
 
       - name: Run generate_files.sh for reown_appkit
         if: github.event.inputs.appkit == 'true'
@@ -516,9 +522,11 @@ jobs:
 
       - name: Configure pub.dev credentials
         if: github.event.inputs.walletkit == 'true'
+        env:
+          PUB_CREDENTIALS: ${{ secrets.PUB_CREDENTIALS }}
         run: |
           mkdir -p $HOME/.config/dart
-          (umask 077 && echo '${{ secrets.PUB_CREDENTIALS }}' > $HOME/.config/dart/pub-credentials.json)
+          (umask 077; printf '%s' "$PUB_CREDENTIALS" > $HOME/.config/dart/pub-credentials.json)
 
       - name: Run generate_files.sh for reown_walletkit
         if: github.event.inputs.walletkit == 'true'
@@ -605,9 +613,11 @@ jobs:
 
       - name: Configure pub.dev credentials
         if: github.event.inputs.yttrium == 'true'
+        env:
+          PUB_CREDENTIALS: ${{ secrets.PUB_CREDENTIALS }}
         run: |
           mkdir -p $HOME/.config/dart
-          (umask 077 && echo '${{ secrets.PUB_CREDENTIALS }}' > $HOME/.config/dart/pub-credentials.json)
+          (umask 077; printf '%s' "$PUB_CREDENTIALS" > $HOME/.config/dart/pub-credentials.json)
 
       - name: Run generate_files.sh for reown_yttrium
         if: github.event.inputs.yttrium == 'true'
@@ -694,9 +704,11 @@ jobs:
 
       - name: Configure pub.dev credentials
         if: github.event.inputs.cli == 'true'
+        env:
+          PUB_CREDENTIALS: ${{ secrets.PUB_CREDENTIALS }}
         run: |
           mkdir -p $HOME/.config/dart
-          (umask 077 && echo '${{ secrets.PUB_CREDENTIALS }}' > $HOME/.config/dart/pub-credentials.json)
+          (umask 077; printf '%s' "$PUB_CREDENTIALS" > $HOME/.config/dart/pub-credentials.json)
 
       - name: Run generate_files.sh for reown_cli
         if: github.event.inputs.cli == 'true'
@@ -783,9 +795,11 @@ jobs:
 
       - name: Configure pub.dev credentials
         if: github.event.inputs.pos == 'true'
+        env:
+          PUB_CREDENTIALS: ${{ secrets.PUB_CREDENTIALS }}
         run: |
           mkdir -p $HOME/.config/dart
-          (umask 077 && echo '${{ secrets.PUB_CREDENTIALS }}' > $HOME/.config/dart/pub-credentials.json)
+          (umask 077; printf '%s' "$PUB_CREDENTIALS" > $HOME/.config/dart/pub-credentials.json)
 
       - name: Run generate_files.sh for pos_client
         if: github.event.inputs.pos == 'true'
@@ -872,9 +886,11 @@ jobs:
 
       - name: Configure pub.dev credentials
         if: github.event.inputs.walletconnect_pay == 'true'
+        env:
+          PUB_CREDENTIALS: ${{ secrets.PUB_CREDENTIALS }}
         run: |
           mkdir -p $HOME/.config/dart
-          (umask 077 && echo '${{ secrets.PUB_CREDENTIALS }}' > $HOME/.config/dart/pub-credentials.json)
+          (umask 077; printf '%s' "$PUB_CREDENTIALS" > $HOME/.config/dart/pub-credentials.json)
 
       - name: Run code generation for walletconnect_pay
         if: github.event.inputs.walletconnect_pay == 'true'

--- a/.github/workflows/publish-packages.yml
+++ b/.github/workflows/publish-packages.yml
@@ -161,8 +161,7 @@ jobs:
         if: github.event.inputs.core == 'true'
         run: |
           mkdir -p $HOME/.config/dart
-          echo '${{ secrets.PUB_CREDENTIALS }}' > $HOME/.config/dart/pub-credentials.json
-          chmod 600 $HOME/.config/dart/pub-credentials.json
+          (umask 077 && echo '${{ secrets.PUB_CREDENTIALS }}' > $HOME/.config/dart/pub-credentials.json)
 
       - name: Run generate_files.sh for reown_core
         if: github.event.inputs.core == 'true'
@@ -274,8 +273,7 @@ jobs:
         if: github.event.inputs.sign == 'true'
         run: |
           mkdir -p $HOME/.config/dart
-          echo '${{ secrets.PUB_CREDENTIALS }}' > $HOME/.config/dart/pub-credentials.json
-          chmod 600 $HOME/.config/dart/pub-credentials.json
+          (umask 077 && echo '${{ secrets.PUB_CREDENTIALS }}' > $HOME/.config/dart/pub-credentials.json)
 
       - name: Run generate_files.sh for reown_sign
         if: github.event.inputs.sign == 'true'
@@ -396,8 +394,7 @@ jobs:
         if: github.event.inputs.appkit == 'true'
         run: |
           mkdir -p $HOME/.config/dart
-          echo '${{ secrets.PUB_CREDENTIALS }}' > $HOME/.config/dart/pub-credentials.json
-          chmod 600 $HOME/.config/dart/pub-credentials.json
+          (umask 077 && echo '${{ secrets.PUB_CREDENTIALS }}' > $HOME/.config/dart/pub-credentials.json)
 
       - name: Run generate_files.sh for reown_appkit
         if: github.event.inputs.appkit == 'true'
@@ -521,8 +518,7 @@ jobs:
         if: github.event.inputs.walletkit == 'true'
         run: |
           mkdir -p $HOME/.config/dart
-          echo '${{ secrets.PUB_CREDENTIALS }}' > $HOME/.config/dart/pub-credentials.json
-          chmod 600 $HOME/.config/dart/pub-credentials.json
+          (umask 077 && echo '${{ secrets.PUB_CREDENTIALS }}' > $HOME/.config/dart/pub-credentials.json)
 
       - name: Run generate_files.sh for reown_walletkit
         if: github.event.inputs.walletkit == 'true'
@@ -611,8 +607,7 @@ jobs:
         if: github.event.inputs.yttrium == 'true'
         run: |
           mkdir -p $HOME/.config/dart
-          echo '${{ secrets.PUB_CREDENTIALS }}' > $HOME/.config/dart/pub-credentials.json
-          chmod 600 $HOME/.config/dart/pub-credentials.json
+          (umask 077 && echo '${{ secrets.PUB_CREDENTIALS }}' > $HOME/.config/dart/pub-credentials.json)
 
       - name: Run generate_files.sh for reown_yttrium
         if: github.event.inputs.yttrium == 'true'
@@ -701,8 +696,7 @@ jobs:
         if: github.event.inputs.cli == 'true'
         run: |
           mkdir -p $HOME/.config/dart
-          echo '${{ secrets.PUB_CREDENTIALS }}' > $HOME/.config/dart/pub-credentials.json
-          chmod 600 $HOME/.config/dart/pub-credentials.json
+          (umask 077 && echo '${{ secrets.PUB_CREDENTIALS }}' > $HOME/.config/dart/pub-credentials.json)
 
       - name: Run generate_files.sh for reown_cli
         if: github.event.inputs.cli == 'true'
@@ -791,8 +785,7 @@ jobs:
         if: github.event.inputs.pos == 'true'
         run: |
           mkdir -p $HOME/.config/dart
-          echo '${{ secrets.PUB_CREDENTIALS }}' > $HOME/.config/dart/pub-credentials.json
-          chmod 600 $HOME/.config/dart/pub-credentials.json
+          (umask 077 && echo '${{ secrets.PUB_CREDENTIALS }}' > $HOME/.config/dart/pub-credentials.json)
 
       - name: Run generate_files.sh for pos_client
         if: github.event.inputs.pos == 'true'
@@ -881,8 +874,7 @@ jobs:
         if: github.event.inputs.walletconnect_pay == 'true'
         run: |
           mkdir -p $HOME/.config/dart
-          echo '${{ secrets.PUB_CREDENTIALS }}' > $HOME/.config/dart/pub-credentials.json
-          chmod 600 $HOME/.config/dart/pub-credentials.json
+          (umask 077 && echo '${{ secrets.PUB_CREDENTIALS }}' > $HOME/.config/dart/pub-credentials.json)
 
       - name: Run code generation for walletconnect_pay
         if: github.event.inputs.walletconnect_pay == 'true'


### PR DESCRIPTION
## Summary

Hardens secret handling in `publish-packages.yml`. Addresses two latent exposure risks flagged in the automated review of #409 — both **pre-existing** (they date to #322, not a known leak). Kept separate from #409 so the release-automation change and this security cleanup review independently.

## Issue 1 — `GITHUB_TOKEN` embedded in git push URLs (MEDIUM)

Before, every push baked the token into the remote URL:
```bash
git push https://x-access-token:${GITHUB_TOKEN}@github.com/${{ github.repository }} <branch>
```
Git can echo that URL (token included) in error output on a failed push, and the colon-prefixed form may slip past the log masker.

**Fix:** all 6 pushes now use `git push origin <branch>`, relying on the credential `actions/checkout` already persists (default `persist-credentials: true`). The token no longer appears in any command or URL. Removed the now-unused `GITHUB_TOKEN` env blocks. `peter-evans/create-pull-request` keeps its own `token:` input.

> Note: the review suggested an explicit `AUTHORIZATION: bearer` extraheader, but GitHub's git-over-HTTPS uses Basic auth, not bearer — hand-rolling it risks either breaking auth or base64-encoding the token into `.git/config` (worse for masking). Leaning on checkout's persisted credential is the idiomatic, lowest-risk form of the same idea.

## Issue 2 — `PUB_CREDENTIALS` written world-readable, never cleaned up (MEDIUM)

This is the **long-lived pub.dev publisher OAuth token** for the `reown.com` namespace — higher value than the ephemeral `GITHUB_TOKEN`. It was written mode-644 and left on disk for the whole job.

**Fix:** `chmod 600` at write time, plus a `Remove pub.dev credentials` step (`if: always()`) immediately after each publish so it doesn't linger through the wait/Slack steps.

## ⚠️ Honest scope note

On GitHub-**hosted** runners (single-user `runner`, ephemeral VM), `chmod 600` and end-of-step cleanup are **defense-in-depth with limited effect** against the actual threat the review cited: a dependency compromised *within the same job* runs as the same user while the creds are present. These changes reduce the persistence window and help on multi-user self-hosted runners, but they are not a complete fix.

The materially stronger follow-ups (recommended, not in this PR):
1. **Write `PUB_CREDENTIALS` just before `pub publish`** (after `generate_files.sh` / `build_runner`) so the untrusted codegen step runs credential-free. This directly closes the cited vector but needs a per-job reorder best done deliberately.
2. **Migrate to pub.dev OIDC "automated publishing"** and drop the `PUB_CREDENTIALS` secret entirely — the real long-term fix.

## Testing

- Workflow YAML parses (10 jobs intact).
- Verified: 0 token-in-URL pushes remain, 6 `git push origin`, 8 `chmod 600`, 8 removal steps, only the peter-evans `token:` reference left.
- Not exercised in a live Actions run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
