### PR TITLE
ci: bootstrap tag release workflow dispatch

### DIFF
--- a/.github/workflows/tag-releases.yml
+++ b/.github/workflows/tag-releases.yml
@@ -11,6 +11,8 @@ on:
         required: false
         default: ""
 
+permissions: {}
+
 jobs:
   bootstrap:
     name: Bootstrap placeholder

--- a/.github/workflows/tag-releases.yml
+++ b/.github/workflows/tag-releases.yml
@@ -1,0 +1,22 @@
+name: Tag Releases
+
+# This bootstrap makes the workflow_dispatch entry point available from the
+# default branch. Select the release-improvements branch when running it to
+# execute the full workflow from PR #409 before that PR is merged.
+on:
+  workflow_dispatch:
+    inputs:
+      target_sha:
+        description: "Commit SHA to tag/target"
+        required: false
+        default: ""
+
+jobs:
+  bootstrap:
+    name: Bootstrap placeholder
+    runs-on: ubuntu-latest
+    steps:
+      - name: Explain how to run the PR workflow
+        run: |
+          echo "This placeholder only bootstraps manual dispatch availability."
+          echo "Select the release-improvements branch to run the full workflow from PR #409."


### PR DESCRIPTION
This bootstrap PR adds a minimal `Tag Releases` workflow at `.github/workflows/tag-releases.yml` so GitHub exposes the manual `workflow_dispatch` entry point from the default branch.

After merging this PR:
1. Set repository variable `TAG_RELEASES_DRY_RUN=true`.
2. Open Actions → Tag Releases → Run workflow.
3. Select branch `release-improvements` to execute the full workflow from PR #409.
4. Use `target_sha` for the source commit to test.

The placeholder itself is safe and only prints instructions; it has no release permissions and does not run on pull requests. PR #409 will replace this file with the full implementation.