### PR TITLE
fix: emit EIP-55 checksummed addresses in SIWE messages

### DIFF
--- a/packages/reown_sign/CHANGELOG.md
+++ b/packages/reown_sign/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 1.4.1
+
+- Emit EIP-55 checksummed addresses in SIWE messages, including uppercase `0X` prefixes.
+
 ## 1.4.0
 
 - Collect Stellar TVF transaction hashes (`stellar_signXDR`, `stellar_signAndSubmitXDR`) in the sign engine.

--- a/packages/reown_sign/lib/utils/address_utils.dart
+++ b/packages/reown_sign/lib/utils/address_utils.dart
@@ -1,3 +1,5 @@
+import 'package:wallet/wallet.dart' as wallet;
+
 class AddressUtils {
   static List<String> _getDidAddressSegments(String iss) {
     return iss.split(':');
@@ -43,9 +45,19 @@ class AddressUtils {
   }
 }
 
+final _evmAddress = RegExp(r'^(0x)?[0-9a-fA-F]{40}$');
+
 extension AddressUtilsExtension on String {
+  /// Checksums an EVM address per EIP-55. Non-EVM values are returned unchanged
+  /// so Solana / Bitcoin accounts are not forced through EthereumAddress.
   String toEIP55() {
-    return this;
-    // return EthereumAddress.fromHex(this).hexEip55;
+    if (!_evmAddress.hasMatch(this)) {
+      return this;
+    }
+    try {
+      return wallet.EthereumAddress.fromHex(this).eip55With0x;
+    } catch (_) {
+      return this;
+    }
   }
 }

--- a/packages/reown_sign/lib/utils/address_utils.dart
+++ b/packages/reown_sign/lib/utils/address_utils.dart
@@ -45,7 +45,7 @@ class AddressUtils {
   }
 }
 
-final _evmAddress = RegExp(r'^(0x)?[0-9a-fA-F]{40}$');
+final _evmAddress = RegExp(r'^(0[xX])?[0-9a-fA-F]{40}$');
 
 extension AddressUtilsExtension on String {
   /// Checksums an EVM address per EIP-55. Non-EVM values are returned unchanged

--- a/packages/reown_sign/test/utils/address_utils_test.dart
+++ b/packages/reown_sign/test/utils/address_utils_test.dart
@@ -21,5 +21,21 @@ void main() {
         TEST_ETHEREUM_CHAIN.split(':')[1],
       );
     });
+
+    test('toEIP55 checksums a lowercase EVM address', () {
+      expect(
+        '0x5aaeb6053f3e94c9b9a09f33669435e7ef1beaed'.toEIP55(),
+        '0x5aAeb6053F3E94C9b9A09f33669435E7Ef1BeAed',
+      );
+    });
+
+    test('toEIP55 keeps an already checksummed address', () {
+      expect(TEST_ADDRESS_EIP191.toEIP55(), TEST_ADDRESS_EIP191);
+    });
+
+    test('toEIP55 leaves non-EVM addresses unchanged', () {
+      const solana = '7EcDhSYGxXyscszYEp35KHN8vvw3svAuLKTzXwCFLtV';
+      expect(solana.toEIP55(), solana);
+    });
   });
 }

--- a/packages/reown_sign/test/utils/address_utils_test.dart
+++ b/packages/reown_sign/test/utils/address_utils_test.dart
@@ -29,6 +29,13 @@ void main() {
       );
     });
 
+    test('toEIP55 checksums an EVM address with an uppercase 0X prefix', () {
+      expect(
+        '0X5aaeb6053f3e94c9b9a09f33669435e7ef1beaed'.toEIP55(),
+        '0x5aAeb6053F3E94C9b9A09f33669435E7Ef1BeAed',
+      );
+    });
+
     test('toEIP55 keeps an already checksummed address', () {
       expect(TEST_ADDRESS_EIP191.toEIP55(), TEST_ADDRESS_EIP191);
     });


### PR DESCRIPTION
## Summary
- `String.toEIP55()` was a no-op (`return this`), so `formatAuthMessage` put lowercase addresses in SIWE messages.
- SIWE libraries that enforce EIP-55 (e.g. spruceid `siwe`) reject those with `Address not conformant to EIP-55`.
- Checksum EVM addresses via `EthereumAddress.fromHex(...).eip55With0x`. Leave Solana / Bitcoin accounts unchanged.

Fixes reown-com/reown_flutter#45

## Test plan
- [x] `cd packages/reown_sign && flutter test test/utils/address_utils_test.dart`
- [x] AppKit SIWE `createMessage` / `SIWEUtils.formatMessage`: address line is checksummed (e.g. `0x958C...` not `0x958c...`)
- [x] Connect a Solana account: address is unchanged
- [x] spruceid `siwe` `new SiweMessage(message)` accepts the formatted message without rewriting the address



