### PR TITLE
fix(cacao): reject expired and not-before timestamps

### DIFF
--- a/packages/reown_sign/lib/sign_engine.dart
+++ b/packages/reown_sign/lib/sign_engine.dart
@@ -1876,6 +1876,13 @@ class ReownSign implements IReownSign {
     final CacaoPayload payload = cacao.p;
 
     try {
+      if (!AuthSignature.isWithinValidityWindow(
+        exp: payload.exp,
+        nbf: payload.nbf,
+      )) {
+        return false;
+      }
+
       final reconstructed = formatAuthMessage(
         iss: payload.iss,
         cacaoPayload: CacaoRequestPayload.fromCacaoPayload(payload),

--- a/packages/reown_sign/lib/utils/auth_signature.dart
+++ b/packages/reown_sign/lib/utils/auth_signature.dart
@@ -1,5 +1,6 @@
 import 'dart:convert';
 import 'dart:typed_data';
+
 import 'package:convert/convert.dart';
 import 'package:http/http.dart' as http;
 
@@ -151,6 +152,29 @@ class AuthSignature {
     } catch (e) {
       return false;
     }
+  }
+
+  /// Returns true when optional CACAO `exp` / `nbf` are absent or [now]
+  /// is inside the validity window. Unparseable timestamps fail closed.
+  static bool isWithinValidityWindow({
+    String? exp,
+    String? nbf,
+    DateTime? now,
+  }) {
+    final clock = now ?? DateTime.now().toUtc();
+    if (exp != null) {
+      final expTime = DateTime.tryParse(exp)?.toUtc();
+      if (expTime == null || !clock.isBefore(expTime)) {
+        return false;
+      }
+    }
+    if (nbf != null) {
+      final nbfTime = DateTime.tryParse(nbf)?.toUtc();
+      if (nbfTime == null || clock.isBefore(nbfTime)) {
+        return false;
+      }
+    }
+    return true;
   }
 
   // verifies CACAO signature

--- a/packages/reown_sign/test/auth/cacao_validity_window_test.dart
+++ b/packages/reown_sign/test/auth/cacao_validity_window_test.dart
@@ -1,0 +1,77 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:reown_sign/reown_sign.dart';
+
+void main() {
+  final now = DateTime.fromMillisecondsSinceEpoch(
+    1700000000 * 1000,
+    isUtc: true,
+  );
+
+  test('absent exp and nbf are valid', () {
+    expect(AuthSignature.isWithinValidityWindow(now: now), isTrue);
+  });
+
+  test('future exp is valid', () {
+    expect(
+      AuthSignature.isWithinValidityWindow(
+        exp: '2024-01-01T00:00:00Z',
+        now: now,
+      ),
+      isTrue,
+    );
+  });
+
+  test('past exp is expired', () {
+    expect(
+      AuthSignature.isWithinValidityWindow(
+        exp: '2023-01-01T00:00:00Z',
+        now: now,
+      ),
+      isFalse,
+    );
+  });
+
+  test('exp equal to now is expired', () {
+    expect(
+      AuthSignature.isWithinValidityWindow(
+        exp: '2023-11-14T22:13:20Z',
+        now: now,
+      ),
+      isFalse,
+    );
+  });
+
+  test('past nbf is valid', () {
+    expect(
+      AuthSignature.isWithinValidityWindow(
+        nbf: '2023-01-01T00:00:00Z',
+        now: now,
+      ),
+      isTrue,
+    );
+  });
+
+  test('future nbf is not yet valid', () {
+    expect(
+      AuthSignature.isWithinValidityWindow(
+        nbf: '2024-01-01T00:00:00Z',
+        now: now,
+      ),
+      isFalse,
+    );
+  });
+
+  test('unparseable exp fails closed', () {
+    expect(
+      AuthSignature.isWithinValidityWindow(exp: 'not-a-timestamp', now: now),
+      isFalse,
+    );
+  });
+
+  test('unparseable nbf fails closed', () {
+    expect(
+      AuthSignature.isWithinValidityWindow(nbf: 'not-a-timestamp', now: now),
+      isFalse,
+    );
+  });
+}


### PR DESCRIPTION
# Description

`validateSignedCacao` checked the signature only. It formatted `exp` and `nbf` into the CAIP-122 message, then returned true for any valid signature, including after `exp`, before `nbf`, or when those fields were unparseable.

Session authenticate in `ReownSign` treats that boolean as the gate (`WalletKit` and `AppKit` forward to the same method). Request-level `expiryTimestamp` is a different field.

Fail closed when `exp` is present and past or unparseable, and when `nbf` is present and future or unparseable. Absent timestamps stay optional, matching CAIP-122 / EIP-4361.

Language-split of WalletConnect/walletconnect-monorepo#7312, reown-com/reown-kotlin#427, reown-com/reown-rust#109, and reown-com/reown-dotnet#322. Distinct from reown-swift#345 (CR/LF) and from #413 (EIP-55 checksum in SIWE text).

**Threat-model:** the attacker already holds a previously valid signed CACAO. They do not control the verifier clock or the key. After `exp` (or before `nbf`) the signature is still valid, and `validateSignedCacao` still returned true. That is replay after expiry, not host or agent authority.

Resolves # (issue)

## How Has This Been Tested?

```
flutter test test/auth/cacao_validity_window_test.dart test/auth/signature_test.dart
```

8/8 new window tests plus existing AuthSignature tests. Clock is injected (`now = 1700000000`). `flutter analyze` on the touched files is clean.

## Due Diligence

* [ ] Breaking change
* [ ] Requires a documentation update