### PR TITLE
ci(publish): fix PR-creation job destroying dep commits + sync dep drift

### DIFF
--- a/.github/workflows/publish-packages.yml
+++ b/.github/workflows/publish-packages.yml
@@ -977,39 +977,40 @@ jobs:
             echo "Branch is not ahead of develop, skipping PR creation"
           fi
 
-      - name: Push all changes
-        if: steps.check_changes.outputs.has_changes == 'true'
-        run: |
-          git config --global user.name 'github-actions[bot]'
-          git config --global user.email 'github-actions[bot]@users.noreply.github.com'
-          git push origin ${{ needs.create-branch.outputs.branch_name }}
-
+      # The dependency-update commits are already pushed to the release branch by the
+      # publish jobs, so the PR must be created from the branch as-is. Do NOT use
+      # peter-evans/create-pull-request here: it builds PRs from uncommitted working-tree
+      # changes and force-resets the branch to base when there are none, destroying the
+      # already-pushed commits (this silently dropped dep updates in runs #69 and #70).
       - name: Create Pull Request
         if: steps.check_changes.outputs.has_changes == 'true'
-        uses: peter-evans/create-pull-request@v5
-        with:
-          token: ${{ secrets.GITHUB_TOKEN }}
-          base: develop
-          branch: ${{ needs.create-branch.outputs.branch_name }}
-          title: "ci: Package dependency updates and releases"
-          body: |
-            This PR contains package dependency updates and releases from the automated publishing workflow.
-
-            ## Packages Published
-            ${{ github.event.inputs.core == 'true' && '- reown_core' || '' }}
-            ${{ github.event.inputs.sign == 'true' && '- reown_sign' || '' }}
-            ${{ github.event.inputs.appkit == 'true' && '- reown_appkit' || '' }}
-            ${{ github.event.inputs.walletkit == 'true' && '- reown_walletkit' || '' }}
-            ${{ github.event.inputs.yttrium == 'true' && '- reown_yttrium' || '' }}
-            ${{ github.event.inputs.cli == 'true' && '- reown_cli' || '' }}
-            ${{ github.event.inputs.pos == 'true' && '- pos_client' || '' }}
-            ${{ github.event.inputs.walletconnect_pay == 'true' && '- walletconnect_pay' || '' }}
-
-            ## Changes
-            - Updated package dependencies to latest published versions
-            - All packages have been successfully published to pub.dev
-
-            This PR was automatically created by the GitHub Actions workflow.
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          {
+            echo "This PR contains package dependency updates and releases from the automated publishing workflow."
+            echo ""
+            echo "## Packages Published"
+            if [[ "${{ github.event.inputs.core }}" == 'true' ]]; then echo "- reown_core"; fi
+            if [[ "${{ github.event.inputs.sign }}" == 'true' ]]; then echo "- reown_sign"; fi
+            if [[ "${{ github.event.inputs.appkit }}" == 'true' ]]; then echo "- reown_appkit"; fi
+            if [[ "${{ github.event.inputs.walletkit }}" == 'true' ]]; then echo "- reown_walletkit"; fi
+            if [[ "${{ github.event.inputs.yttrium }}" == 'true' ]]; then echo "- reown_yttrium"; fi
+            if [[ "${{ github.event.inputs.cli }}" == 'true' ]]; then echo "- reown_cli"; fi
+            if [[ "${{ github.event.inputs.pos }}" == 'true' ]]; then echo "- pos_client"; fi
+            if [[ "${{ github.event.inputs.walletconnect_pay }}" == 'true' ]]; then echo "- walletconnect_pay"; fi
+            echo ""
+            echo "## Changes"
+            echo "- Updated package dependencies to latest published versions"
+            echo "- All packages have been successfully published to pub.dev"
+            echo ""
+            echo "This PR was automatically created by the GitHub Actions workflow."
+          } > pr_body.md
+          gh pr create \
+            --base develop \
+            --head "${{ needs.create-branch.outputs.branch_name }}" \
+            --title "ci: Package dependency updates and releases" \
+            --body-file pr_body.md
 
 # Launch locally
 # act --container-architecture linux/amd64 -P ubuntu-latest=-self-hosted --secret-file .github/workflows/.env.secret -W .github/workflows/publish-packages.yml workflow_dispatch

--- a/packages/reown_appkit/pubspec.yaml
+++ b/packages/reown_appkit/pubspec.yaml
@@ -30,7 +30,7 @@ dependencies:
   pinenacl: ^0.6.0
   plugin_platform_interface: ^2.1.8
   qr_flutter_wc: ^0.0.3
-  reown_core: ^1.3.8
+  reown_core: ^1.4.0
   reown_sign: ^1.3.9
   shimmer: ^3.0.0
   synchronized: ^3.3.0+3

--- a/packages/reown_walletkit/pubspec.yaml
+++ b/packages/reown_walletkit/pubspec.yaml
@@ -15,7 +15,7 @@ dependencies:
     sdk: flutter
   reown_core: ^1.3.8
   reown_sign: ^1.3.9
-  walletconnect_pay: ^1.0.0
+  walletconnect_pay: ^1.0.1
 
 dev_dependencies:
   build_runner: ^2.4.13


### PR DESCRIPTION
## Problem

The `create-pull-request` job in `publish-packages.yml` used `peter-evans/create-pull-request@v5`, which builds PRs from **uncommitted working-tree changes** and force-resets the branch to base when there are none. Since the publish jobs already commit and push their dependency rewrites to the release branch, the action always found a clean tree, **force-reset the branch — destroying the already-pushed dep-update commits** — and never opened a PR.

This silently happened in run #69 (Aug 4) and run #70 (Aug 26): the packages published to pub.dev carry the correct dependency versions, but the commits recording them on the release branch were wiped, so `develop` drifted from what was shipped.

## Changes

**Workflow fix** — replace the `peter-evans/create-pull-request` step (and the redundant push step) with a plain `gh pr create` against the already-pushed release branch. It can't rewrite the branch, and it fails loudly instead of silently if PR creation is not permitted.

**Dependency drift sync** — restore the two bumps the old job destroyed, matching what is actually published on pub.dev:

| Package | Dependency | Before | After | Lost in |
|---|---|---|---|---|
| `reown_walletkit` | `walletconnect_pay` | `^1.0.0` | `^1.0.1` | run #70 |
| `reown_appkit` | `reown_core` | `^1.3.8` | `^1.4.0` | run #69 |

## Notes

- No functional impact on consumers (caret ranges already resolved to the published versions); this makes `develop` truthful again.
- If the repo/org setting "Allow GitHub Actions to create and approve pull requests" is disabled, `gh pr create` will fail visibly — the correct behavior compared to the old silent branch reset.

🤖 Generated with [Claude Code](https://claude.com/claude-code)