### PR TITLE
fix(ci): update Foundry toolchain action

### DIFF
--- a/.github/workflows/e2e_balance_check.yml
+++ b/.github/workflows/e2e_balance_check.yml
@@ -26,7 +26,7 @@ jobs:
       SLACK_FAUCETBOT_WEBHOOK_URL: ${{ secrets.SLACK_FAUCETBOT_WEBHOOK_URL }}
     steps:
       - name: Install Foundry
-        uses: foundry-rs/foundry-toolchain@8789b3e21e6c11b2697f5eb56eddae542f746c10 # v1
+        uses: foundry-rs/foundry-toolchain@908c540300062bd5a7e473851cdb4282204cee09 # v1.9.1
 
       # USDT on Polygon funds the pay_usdt_polygon Permit2 flow (the actual payment).
       - name: Check USDT balance on Polygon


### PR DESCRIPTION
## Summary

- update foundry-rs/foundry-toolchain from v1.7.0 to the immutable v1.9.1 SHA
- use the action release that executes the new native foundryup binary correctly
- preserve the existing stable Foundry and cache behavior

## Context

Foundry changed its legacy installer on August 25 to install the Rust foundryup binary. The old action invokes that binary through Bash and exits with cannot execute binary file.

Upstream change: https://github.com/foundry-rs/foundry/commit/f830add66a9fd9f99fccdf4c524de53341bf0571

## Validation

- YAML syntax and git diff checks pass
- the same v1.9.1 SHA successfully installed cast 1.7.1 and completed the balance workflow on Ubuntu: https://github.com/reown-com/react-native-examples/actions/runs/32976263608