### PR TITLE
chore: bump versions for Stellar TVF release

### DIFF
--- a/packages/reown_appkit/CHANGELOG.md
+++ b/packages/reown_appkit/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 1.9.0
+
+- Stellar TVF support via reown_core 1.5.0 and reown_sign 1.4.0.
+
 ## 1.8.4
 
 - Fixed wallet install detection

--- a/packages/reown_appkit/pubspec.yaml
+++ b/packages/reown_appkit/pubspec.yaml
@@ -1,6 +1,6 @@
 name: reown_appkit
 description: "Reown is the onchain UX platform that provides toolkits built on top of the WalletConnect Network"
-version: 1.8.4
+version: 1.9.0
 homepage: https://github.com/reown-com/reown_flutter
 repository: https://github.com/reown-com/reown_flutter/tree/master/packages/reown_appkit
 documentation: https://docs.reown.com/appkit/flutter/core/installation

--- a/packages/reown_core/CHANGELOG.md
+++ b/packages/reown_core/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 1.5.0
+
+- Added Stellar TVF support: compute the transaction hash from signed `stellar_signXDR` envelopes (V0, V1 and fee-bump) and extract `tx_hash` from `stellar_signAndSubmitXDR` responses.
+
 ## 1.4.0
 
 - Upgraded `flutter_secure_storage` to `^10.0.0`. Existing data stored via the

--- a/packages/reown_core/pubspec.yaml
+++ b/packages/reown_core/pubspec.yaml
@@ -1,6 +1,6 @@
 name: reown_core
 description: "Reown is the onchain UX platform that provides toolkits built on top of the WalletConnect Network"
-version: 1.4.0
+version: 1.5.0
 homepage: https://github.com/reown-com/reown_flutter
 repository: https://github.com/reown-com/reown_flutter/tree/master/packages/reown_core
 

--- a/packages/reown_sign/CHANGELOG.md
+++ b/packages/reown_sign/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 1.4.0
+
+- Collect Stellar TVF transaction hashes (`stellar_signXDR`, `stellar_signAndSubmitXDR`) in the sign engine.
+
 ## 1.3.9
 
 - Dependency updates

--- a/packages/reown_sign/pubspec.yaml
+++ b/packages/reown_sign/pubspec.yaml
@@ -1,6 +1,6 @@
 name: reown_sign
 description: "Reown is the onchain UX platform that provides toolkits built on top of the WalletConnect Network"
-version: 1.3.9
+version: 1.4.0
 homepage: https://github.com/reown-com/reown_flutter
 repository: https://github.com/reown-com/reown_flutter/tree/master/packages/reown_sign
 

--- a/packages/reown_walletkit/CHANGELOG.md
+++ b/packages/reown_walletkit/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 1.5.0
+
+- Stellar TVF support (transaction hash reporting for `stellar_signXDR` / `stellar_signAndSubmitXDR`) via reown_core 1.5.0 and reown_sign 1.4.0.
+
 ## 1.4.1
 
 - Dependency updates (`walletconnect_pay`, `reown_yttrium`)

--- a/packages/reown_walletkit/pubspec.yaml
+++ b/packages/reown_walletkit/pubspec.yaml
@@ -1,6 +1,6 @@
 name: reown_walletkit
 description: "Reown is the onchain UX platform that provides toolkits built on top of the WalletConnect Network"
-version: 1.4.1
+version: 1.5.0
 homepage: https://github.com/reown-com/reown_flutter
 repository: https://github.com/reown-com/reown_flutter/tree/master/packages/reown_walletkit
 documentation: https://docs.walletconnect.network/wallet-sdk/flutter/installation


### PR DESCRIPTION
## Why

The [publish run](https://github.com/reown-com/reown_flutter/actions/runs/33065021425) failed at `Publish reown_core`:

> Message from server: Version 1.4.0 of package reown_core already exists.

Versions were never bumped after the Stellar TVF feature (#414) merged, so pub.dev rejected the upload and `reown_sign` / `reown_appkit` / `reown_walletkit` were skipped downstream (all four sit exactly at their published versions).

## What

Minor bumps (new backwards-compatible feature) + changelog entries:

| Package | pub.dev | new |
|---|---|---|
| reown_core | 1.4.0 | **1.5.0** |
| reown_sign | 1.3.9 | **1.4.0** |
| reown_walletkit | 1.4.1 | **1.5.0** |
| reown_appkit | 1.8.4 | **1.9.0** |

Dependency pins and `version.dart` regeneration are handled by the publish workflow itself.

## After merging

Re-run **Publish Reown Flutter Packages** from `develop` with Core + Sign + WalletKit (+ AppKit if desired). The release-branch PR created by the failed run can be closed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)