### PR TITLE
ci(publish): rebase-retry release-branch pushes; bump appkit dep pins

### DIFF
--- a/.github/workflows/publish-packages.yml
+++ b/.github/workflows/publish-packages.yml
@@ -146,7 +146,16 @@ jobs:
           if [[ -n $(git status -s pubspec.yaml) ]]; then
             git add pubspec.yaml
             git commit -m "ci(reown_core): Update reown_yttrium to ^${{ needs.publish-yttrium.outputs.package_version }} [skip ci]"
-            git push origin ${{ needs.create-branch.outputs.branch_name }}
+            # Parallel package jobs push to the same release branch; rebase-retry to
+            # avoid non-fast-forward rejections (e.g. the walletkit/appkit race).
+            for attempt in 1 2 3 4 5; do
+              if git pull --rebase origin ${{ needs.create-branch.outputs.branch_name }} && git push origin ${{ needs.create-branch.outputs.branch_name }}; then
+                break
+              fi
+              if [[ $attempt -eq 5 ]]; then echo "Failed to push after 5 attempts"; exit 1; fi
+              echo "Push rejected (concurrent update on release branch), retrying ($attempt)..."
+              sleep $((RANDOM % 4 + 2))
+            done
           else
             echo "No changes to commit in reown_core/pubspec.yaml"
           fi
@@ -260,7 +269,16 @@ jobs:
           if [[ -n $(git status -s pubspec.yaml) ]]; then
             git add pubspec.yaml
             git commit -m "ci(reown_sign): Update reown_core to ^${{ needs.publish-core.outputs.package_version }} [skip ci]"
-            git push origin ${{ needs.create-branch.outputs.branch_name }}
+            # Parallel package jobs push to the same release branch; rebase-retry to
+            # avoid non-fast-forward rejections (e.g. the walletkit/appkit race).
+            for attempt in 1 2 3 4 5; do
+              if git pull --rebase origin ${{ needs.create-branch.outputs.branch_name }} && git push origin ${{ needs.create-branch.outputs.branch_name }}; then
+                break
+              fi
+              if [[ $attempt -eq 5 ]]; then echo "Failed to push after 5 attempts"; exit 1; fi
+              echo "Push rejected (concurrent update on release branch), retrying ($attempt)..."
+              sleep $((RANDOM % 4 + 2))
+            done
           else
             echo "No changes to commit in reown_sign/pubspec.yaml"
           fi
@@ -383,7 +401,16 @@ jobs:
           if [[ -n $(git status -s pubspec.yaml) ]]; then
             git add pubspec.yaml
             git commit -m "ci(reown_appkit): Update core/sign dependencies [skip ci]"
-            git push origin ${{ needs.create-branch.outputs.branch_name }}
+            # Parallel package jobs push to the same release branch; rebase-retry to
+            # avoid non-fast-forward rejections (e.g. the walletkit/appkit race).
+            for attempt in 1 2 3 4 5; do
+              if git pull --rebase origin ${{ needs.create-branch.outputs.branch_name }} && git push origin ${{ needs.create-branch.outputs.branch_name }}; then
+                break
+              fi
+              if [[ $attempt -eq 5 ]]; then echo "Failed to push after 5 attempts"; exit 1; fi
+              echo "Push rejected (concurrent update on release branch), retrying ($attempt)..."
+              sleep $((RANDOM % 4 + 2))
+            done
           else
             echo "No changes to commit in reown_appkit/pubspec.yaml"
           fi
@@ -509,7 +536,16 @@ jobs:
           if [[ -n $(git status -s pubspec.yaml) ]]; then
             git add pubspec.yaml
             git commit -m "ci(reown_walletkit): Update core/sign/walletconnect_pay dependencies [skip ci]"
-            git push origin ${{ needs.create-branch.outputs.branch_name }}
+            # Parallel package jobs push to the same release branch; rebase-retry to
+            # avoid non-fast-forward rejections (e.g. the walletkit/appkit race).
+            for attempt in 1 2 3 4 5; do
+              if git pull --rebase origin ${{ needs.create-branch.outputs.branch_name }} && git push origin ${{ needs.create-branch.outputs.branch_name }}; then
+                break
+              fi
+              if [[ $attempt -eq 5 ]]; then echo "Failed to push after 5 attempts"; exit 1; fi
+              echo "Push rejected (concurrent update on release branch), retrying ($attempt)..."
+              sleep $((RANDOM % 4 + 2))
+            done
           else
             echo "No changes to commit in reown_walletkit/pubspec.yaml"
           fi

--- a/packages/reown_appkit/pubspec.yaml
+++ b/packages/reown_appkit/pubspec.yaml
@@ -30,8 +30,8 @@ dependencies:
   pinenacl: ^0.6.0
   plugin_platform_interface: ^2.1.8
   qr_flutter_wc: ^0.0.3
-  reown_core: ^1.3.8
-  reown_sign: ^1.3.9
+  reown_core: ^1.5.0
+  reown_sign: ^1.4.0
   shimmer: ^3.0.0
   synchronized: ^3.3.0+3
   web_socket_channel: ^3.0.1


### PR DESCRIPTION
## What happened in [run 33067809180](https://github.com/reown-com/reown_flutter/actions/runs/33067809180)

✅ `reown_core 1.5.0`, `reown_sign 1.4.0`, `reown_walletkit 1.5.0` published.
❌ `reown_appkit` failed **before publishing** at *Commit and push pubspec.yaml changes*:

```
! [rejected]  publish_workflow_72 -> publish_workflow_72 (fetch first)
error: failed to push some refs
```

`walletkit` and `appkit` run **in parallel** after `sign`, and both push a dep-update commit to the same release branch with a bare `git push` — first one wins, second is rejected, and the loser's pub.dev publish is skipped. This race fires whenever both are selected.

## Fix

1. **Rebase-retry loop** around all four per-package release-branch pushes (5 attempts with jitter) — parallel jobs now serialize instead of failing. The final *Push all changes* step is untouched to avoid conflicting with #418, which rewrites that area (complementary fixes).
2. **Bump `reown_appkit` pins** to `reown_core: ^1.5.0` / `reown_sign: ^1.4.0` — the workflow's own pin-update step only runs when core/sign are selected in the same run, so an **appkit-only** re-run would otherwise publish with the old pins.

## After merging

Re-run **Publish Reown Flutter Packages** from `develop` with **only `Publish AppKit? = true`** (core/sign/walletkit are already on pub.dev — re-selecting them would fail with "version already exists").

🤖 Generated with [Claude Code](https://claude.com/claude-code)