### PR TITLE
fix(ios): un-pin AppKit production provisioning profile specifier

### DIFF
--- a/packages/reown_appkit/example/base/ios/Runner.xcodeproj/project.pbxproj
+++ b/packages/reown_appkit/example/base/ios/Runner.xcodeproj/project.pbxproj
@@ -812,7 +812,7 @@
 				PRODUCT_BUNDLE_IDENTIFIER = com.walletconnect.flutterdapp;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
-				"PROVISIONING_PROFILE_SPECIFIER[sdk=iphoneos*]" = "match AppStore com.walletconnect.flutterdapp 1758893604";
+				"PROVISIONING_PROFILE_SPECIFIER[sdk=iphoneos*]" = "match AppStore com.walletconnect.flutterdapp";
 				SWIFT_OBJC_BRIDGING_HEADER = "Runner/Runner-Bridging-Header.h";
 				SWIFT_VERSION = 5.0;
 				VERSIONING_SYSTEM = "apple-generic";


### PR DESCRIPTION
## Problem

The **Release AppKit** workflow ([run 33676172120](https://github.com/reown-com/reown_flutter/actions/runs/33676172120/job/100401294421)) failed on the **iOS lane** at the `gym` archive step:

```
error: No profile for team 'W5R8AG9K22' matching
'match AppStore com.walletconnect.flutterdapp 1758893604' found
** ARCHIVE FAILED ** (Exit status: 65)
```

Android passed; only iOS `production` broke.

## Root cause

`packages/reown_appkit/example/base/ios/Runner.xcodeproj/project.pbxproj` pinned the `Release-production` `PROVISIONING_PROFILE_SPECIFIER` to a **timestamped** profile name:

```
match AppStore com.walletconnect.flutterdapp 1758893604
```

`match` (readonly in CI) installs the **untimestamped** profile `match AppStore com.walletconnect.flutterdapp`, so `xcodebuild` couldn't resolve the pinned name. The `internal` config never had the timestamp, which is why only `production` failed. The suffix was almost certainly written by Xcode's Signing UI locally.

## Fix

Drop the timestamp so the specifier matches what `match` installs.

```diff
- "PROVISIONING_PROFILE_SPECIFIER[sdk=iphoneos*]" = "match AppStore com.walletconnect.flutterdapp 1758893604";
+ "PROVISIONING_PROFILE_SPECIFIER[sdk=iphoneos*]" = "match AppStore com.walletconnect.flutterdapp";
```

## Note

Opening this project in Xcode's Signing & Capabilities tab may re-add the timestamp. Edit the `.pbxproj` directly rather than via the UI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)