### PR TITLE
fix: parse SIWE Chain ID from the structured field only

### DIFF
--- a/packages/reown_sign/CHANGELOG.md
+++ b/packages/reown_sign/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 1.4.1
+
+- Parse SIWE `Chain ID` from the structured field so a statement that mentions another chain does not change `personal_sign` routing.
+
 ## 1.4.0
 
 - Collect Stellar TVF transaction hashes (`stellar_signXDR`, `stellar_signAndSubmitXDR`) in the sign engine.

--- a/packages/reown_sign/lib/utils/auth_signature.dart
+++ b/packages/reown_sign/lib/utils/auth_signature.dart
@@ -289,7 +289,12 @@ class AuthSignature {
       String? last;
       for (final line in message.split('\n')) {
         if (line.startsWith(prefix)) {
-          last = line.substring(prefix.length).trim();
+          final match = RegExp(
+            r'^\d+',
+          ).firstMatch(line.substring(prefix.length).trim());
+          if (match != null) {
+            last = match.group(0);
+          }
         }
       }
       return last ?? '';

--- a/packages/reown_sign/lib/utils/auth_signature.dart
+++ b/packages/reown_sign/lib/utils/auth_signature.dart
@@ -285,12 +285,14 @@ class AuthSignature {
 
   static String getChainIdFromMessage(String message) {
     try {
-      const pattern = 'Chain ID: ';
-      final regexp = RegExp('$pattern(?<temp1>\\d+)');
-      final matches = regexp.allMatches(message);
-      for (final Match m in matches) {
-        return m[0]!.toString().replaceAll(pattern, '');
+      const prefix = 'Chain ID: ';
+      String? last;
+      for (final line in message.split('\n')) {
+        if (line.startsWith(prefix)) {
+          last = line.substring(prefix.length).trim();
+        }
       }
+      return last ?? '';
     } catch (_) {}
     return '';
   }

--- a/packages/reown_sign/test/auth/signature_test.dart
+++ b/packages/reown_sign/test/auth/signature_test.dart
@@ -113,6 +113,17 @@ Issued At: 2022-10-10T23:03:35.700Z''';
         AuthSignature.getChainIdFromMessage(statementMentionsAnotherChain),
         '1',
       );
+
+      const trailingTextOnField = '''
+example.com wants you to sign in with your Ethereum account:
+0x06C6A22feB5f8CcEDA0db0D593e6F26A3611d5fa
+
+URI: https://example.com/login
+Version: 1
+Chain ID: 1 (mainnet)
+Nonce: 100
+Issued At: 2022-10-10T23:03:35.700Z''';
+      expect(AuthSignature.getChainIdFromMessage(trailingTextOnField), '1');
     });
 
     // TODO: Fix this test, can't call http requests from within the test

--- a/packages/reown_sign/test/auth/signature_test.dart
+++ b/packages/reown_sign/test/auth/signature_test.dart
@@ -97,6 +97,22 @@ void main() {
         TEST_MESSAGE_EIP1271_2,
       );
       expect(chainId3, '465321');
+
+      const statementMentionsAnotherChain = '''
+example.com wants you to sign in with your Ethereum account:
+0x06C6A22feB5f8CcEDA0db0D593e6F26A3611d5fa
+
+Please use Chain ID: 137 for Polygon.
+
+URI: https://example.com/login
+Version: 1
+Chain ID: 1
+Nonce: 100
+Issued At: 2022-10-10T23:03:35.700Z''';
+      expect(
+        AuthSignature.getChainIdFromMessage(statementMentionsAnotherChain),
+        '1',
+      );
     });
 
     // TODO: Fix this test, can't call http requests from within the test


### PR DESCRIPTION
## Summary
Hey @ignaciosantise / Reown team — `getChainIdFromMessage` was taking the first `Chain ID: <digits>` anywhere in the SIWE text.

If the statement says something like "Please use Chain ID: 137", AppKit then sends `personal_sign` on Polygon even when the real field is `Chain ID: 1`. This now only reads lines that start with `Chain ID: `.

## Test plan
- [x] `cd packages/reown_sign && flutter test test/auth/signature_test.dart`
- [x] SIWE statement mentions another chain; signing still uses the structured `Chain ID` line