### PR TITLE
fix: stamp SIWE iat with real UTC

### DIFF
--- a/packages/reown_appkit/CHANGELOG.md
+++ b/packages/reown_appkit/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 1.9.1
+
+- Stamp SIWE `iat` with real UTC instead of labeling local wall-clock time as `Z`.
+
 ## 1.9.0
 
 - Stellar TVF support via reown_core 1.5.0 and reown_sign 1.4.0.

--- a/packages/reown_appkit/lib/modal/models/public/appkit_siwe_config.dart
+++ b/packages/reown_appkit/lib/modal/models/public/appkit_siwe_config.dart
@@ -80,23 +80,12 @@ sealed class SIWECreateMessageArgs with _$SIWECreateMessageArgs {
     required String nonce,
     required CacaoHeader type,
   }) {
-    final now = DateTime.now();
     return SIWECreateMessageArgs(
       chainId: chainId,
       nonce: nonce,
       address: address,
       version: '1',
-      iat:
-          params.iat ??
-          DateTime.utc(
-            now.year,
-            now.month,
-            now.day,
-            now.hour,
-            now.minute,
-            now.second,
-            now.millisecond,
-          ).toIso8601String(),
+      iat: params.iat ?? DateTime.now().toUtc().toIso8601String(),
       domain: params.domain,
       uri: params.uri,
       type: type,

--- a/packages/reown_appkit/test/siwe_iat_utc_test.dart
+++ b/packages/reown_appkit/test/siwe_iat_utc_test.dart
@@ -1,0 +1,25 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:reown_appkit/reown_appkit.dart';
+
+void main() {
+  test('SIWECreateMessageArgs default iat is real UTC', () {
+    final before = DateTime.now().toUtc();
+    final args = SIWECreateMessageArgs.fromSIWEMessageArgs(
+      const SIWEMessageArgs(
+        domain: 'example.com',
+        uri: 'https://example.com/login',
+      ),
+      address: '0x06C6A22feB5f8CcEDA0db0D593e6F26A3611d5fa',
+      chainId: 'eip155:1',
+      nonce: 'n',
+      type: const CacaoHeader(t: 'eip4361'),
+    );
+    final after = DateTime.now().toUtc();
+    final iat = DateTime.parse(args.iat!);
+
+    expect(args.iat!.endsWith('Z'), isTrue);
+    expect(iat.isUtc, isTrue);
+    expect(!iat.isBefore(before.subtract(const Duration(seconds: 1))), isTrue);
+    expect(!iat.isAfter(after.add(const Duration(seconds: 1))), isTrue);
+  });
+}

--- a/packages/reown_sign/CHANGELOG.md
+++ b/packages/reown_sign/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 1.4.1
+
+- Stamp SIWE / CACAO `iat` with real UTC instead of labeling local wall-clock time as `Z`.
+
 ## 1.4.0
 
 - Collect Stellar TVF transaction hashes (`stellar_signXDR`, `stellar_signAndSubmitXDR`) in the sign engine.

--- a/packages/reown_sign/lib/models/session_auth_models.dart
+++ b/packages/reown_sign/lib/models/session_auth_models.dart
@@ -76,7 +76,6 @@ sealed class SessionAuthPayload with _$SessionAuthPayload {
   factory SessionAuthPayload.fromRequestParams(
     SessionAuthRequestParams params,
   ) {
-    final now = DateTime.now();
     return SessionAuthPayload(
       chains: params.chains,
       domain: params.domain,
@@ -84,15 +83,7 @@ sealed class SessionAuthPayload with _$SessionAuthPayload {
       aud: params.uri,
       type: params.type?.t ?? 'eip4361',
       version: '1',
-      iat: DateTime.utc(
-        now.year,
-        now.month,
-        now.day,
-        now.hour,
-        now.minute,
-        now.second,
-        now.millisecond,
-      ).toIso8601String(),
+      iat: DateTime.now().toUtc().toIso8601String(),
       nbf: params.nbf,
       exp: params.exp,
       statement: params.statement,

--- a/packages/reown_sign/test/models/session_auth_payload_test.dart
+++ b/packages/reown_sign/test/models/session_auth_payload_test.dart
@@ -1,0 +1,38 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:reown_sign/reown_sign.dart';
+
+void main() {
+  test('fromRequestParams stamps iat in real UTC, not local clock as Z', () {
+    final before = DateTime.now().toUtc();
+    final payload = SessionAuthPayload.fromRequestParams(
+      const SessionAuthRequestParams(
+        domain: 'example.com',
+        chains: ['eip155:1'],
+        nonce: 'n',
+        uri: 'https://example.com/login',
+      ),
+    );
+    final after = DateTime.now().toUtc();
+    final iat = DateTime.parse(payload.iat);
+
+    expect(payload.iat.endsWith('Z'), isTrue);
+    expect(iat.isUtc, isTrue);
+    expect(!iat.isBefore(before.subtract(const Duration(seconds: 1))), isTrue);
+    expect(!iat.isAfter(after.add(const Duration(seconds: 1))), isTrue);
+
+    final localAsUtc = DateTime.utc(
+      DateTime.now().year,
+      DateTime.now().month,
+      DateTime.now().day,
+      DateTime.now().hour,
+      DateTime.now().minute,
+      DateTime.now().second,
+    );
+    if (DateTime.now().timeZoneOffset.inMinutes.abs() >= 2) {
+      expect(
+        iat.difference(localAsUtc).inMinutes.abs(),
+        greaterThanOrEqualTo(1),
+      );
+    }
+  });
+}


### PR DESCRIPTION
## Summary
Hey Reown team — `SessionAuthPayload.fromRequestParams` and `SIWECreateMessageArgs.fromSIWEMessageArgs` were doing `DateTime.utc(local year, local hour, ...)`.

That labels wall-clock time as `Z`. In UTC+4, `Issued At` is four hours off. Both now use `DateTime.now().toUtc()`.

## Test plan
- [x] `cd packages/reown_sign && flutter test test/models/session_auth_payload_test.dart`
- [x] `cd packages/reown_appkit && flutter test test/siwe_iat_utc_test.dart`
- [x] Create a SIWE message outside UTC and confirm `Issued At` matches real UTC