### PR TITLE
fix: delete the corrupt GenericStore bucket on restore failure

### DIFF
--- a/packages/reown_core/CHANGELOG.md
+++ b/packages/reown_core/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 1.5.1
+
+- Delete the corrupt store bucket on GenericStore restore failure instead of the version metadata key.
+
 ## 1.5.0
 
 - Added Stellar TVF support: compute the transaction hash from signed `stellar_signXDR` envelopes (V0, V1 and fee-bump) and extract `tx_hash` from `stellar_signAndSubmitXDR` responses.

--- a/packages/reown_core/lib/store/generic_store.dart
+++ b/packages/reown_core/lib/store/generic_store.dart
@@ -142,8 +142,8 @@ class GenericStore<T> implements IGenericStore<T> {
         }
       } catch (e) {
         // print('Error restoring $storageKey: $e');
-        await storage.delete(storedVersion);
-        onError.broadcast(StoreErrorEvent<String>(storedVersion, e.toString()));
+        await storage.delete(storageKey);
+        onError.broadcast(StoreErrorEvent<String>(storageKey, e.toString()));
       }
     }
   }

--- a/packages/reown_core/test/store_test.dart
+++ b/packages/reown_core/test/store_test.dart
@@ -159,6 +159,7 @@ void main() {
         await onErrorCompleter.future;
 
         expect(store.get('invalid'), {'version': 'swag'});
+        expect(store.get('swag//invalid'), isNull);
         expect(genericStore.has('key'), false);
         expect(genericStore.get('key') == null, true);
       });

--- a/packages/reown_core/test/store_test.dart
+++ b/packages/reown_core/test/store_test.dart
@@ -159,7 +159,7 @@ void main() {
         await onErrorCompleter.future;
 
         expect(store.get('invalid'), {'version': 'swag'});
-        expect(store.get('swag//invalid'), isNull);
+        expect(store.get(genericStore.storageKey), isNull);
         expect(genericStore.has('key'), false);
         expect(genericStore.get('key') == null, true);
       });


### PR DESCRIPTION
## Summary
Hey @ignaciosantise — when GenericStore hits invalid JSON on restore, it was deleting the version metadata key (`swag`) instead of the data bucket (`swag//context`).

The bad payload stayed on disk and failed again on every `init()`. This deletes `storageKey` and reports that key on the error event.

## Test plan
- [x] `cd packages/reown_core && flutter test test/store_test.dart`