### PR TITLE
fix: handle Magic personal_sign from ReownAppKitModal

### DIFF
--- a/packages/reown_appkit/CHANGELOG.md
+++ b/packages/reown_appkit/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 1.9.1
+
+- Show the Magic approve page from `ReownAppKitModal` when social login SIWE asks for `personal_sign`, so verification can run without keeping `AppKitModalAccountButton` mounted.
+
 ## 1.9.0
 
 - Stellar TVF support via reown_core 1.5.0 and reown_sign 1.4.0.

--- a/packages/reown_appkit/lib/modal/appkit_modal_impl.dart
+++ b/packages/reown_appkit/lib/modal/appkit_modal_impl.dart
@@ -43,6 +43,7 @@ import 'package:reown_appkit/modal/utils/platform_utils.dart';
 import 'package:reown_appkit/modal/constants/key_constants.dart';
 import 'package:reown_appkit/modal/constants/string_constants.dart';
 import 'package:reown_appkit/modal/pages/account_page.dart';
+import 'package:reown_appkit/modal/pages/approve_magic_request_page.dart';
 import 'package:reown_appkit/modal/pages/approve_siwe.dart';
 import 'package:reown_appkit/modal/services/analytics_service/analytics_service.dart';
 import 'package:reown_appkit/modal/services/analytics_service/models/analytics_event.dart';
@@ -2291,6 +2292,14 @@ extension _EmailConnectorExtension on ReownAppKitModal {
   }
 
   void _onMagicRequest(MagicRequestEvent? args) {
+    if (args?.request != null) {
+      if (_isOpen) {
+        _widgetStack.push(const ApproveTransactionPage());
+      } else {
+        openModalView(const ApproveTransactionPage());
+      }
+      return;
+    }
     if (args?.result != null) {
       if (args!.result is JsonRpcError && _widgetStack.canPop()) {
         _widgetStack.pop();

--- a/packages/reown_appkit/lib/modal/appkit_modal_impl.dart
+++ b/packages/reown_appkit/lib/modal/appkit_modal_impl.dart
@@ -2293,6 +2293,9 @@ extension _EmailConnectorExtension on ReownAppKitModal {
 
   void _onMagicRequest(MagicRequestEvent? args) {
     if (args?.request != null) {
+      if (_widgetStack.containsKey(KeyConstants.approveTransactionPage)) {
+        return;
+      }
       if (_isOpen) {
         _widgetStack.push(const ApproveTransactionPage());
       } else {

--- a/packages/reown_appkit/lib/modal/widgets/public/appkit_modal_account_button.dart
+++ b/packages/reown_appkit/lib/modal/widgets/public/appkit_modal_account_button.dart
@@ -1,6 +1,5 @@
 import 'package:flutter/material.dart';
 import 'package:get_it/get_it.dart';
-import 'package:reown_appkit/modal/pages/approve_magic_request_page.dart';
 import 'package:reown_appkit/modal/pages/social_login_page.dart';
 import 'package:reown_appkit/modal/services/explorer_service/i_explorer_service.dart';
 import 'package:reown_appkit/modal/services/magic_service/i_magic_service.dart';
@@ -46,15 +45,12 @@ class _AppKitModalAccountButtonState extends State<AppKitModalAccountButton> {
     super.initState();
     _modalNotifyListener();
     widget.appKitModal.addListener(_modalNotifyListener);
-    // TODO [AppKitModalAccountButton] this should go in ReownAppKitModal but for that, init() method of ReownAppKitModal should receive a BuildContext, which would be a breaking change
-    _magicService.onMagicRpcRequest.subscribe(_approveSign);
     _magicService.onMagicLoginRequest.subscribe(_loginRequested);
   }
 
   @override
   void dispose() {
     widget.appKitModal.removeListener(_modalNotifyListener);
-    _magicService.onMagicRpcRequest.unsubscribe(_approveSign);
     _magicService.onMagicLoginRequest.unsubscribe(_loginRequested);
     super.dispose();
   }
@@ -70,16 +66,6 @@ class _AppKitModalAccountButtonState extends State<AppKitModalAccountButton> {
 
   void _onTap() {
     widget.appKitModal.openModalView();
-  }
-
-  void _approveSign(MagicRequestEvent? args) async {
-    if (args?.request != null) {
-      if (widget.appKitModal.isOpen) {
-        _widgetStack.push(ApproveTransactionPage());
-      } else {
-        widget.appKitModal.openModalView(ApproveTransactionPage());
-      }
-    }
   }
 
   void _loginRequested(MagicSessionEvent? args) {


### PR DESCRIPTION
## Summary
Hey @ignaciosantise — this is the social+SIWE hang from #41.

Nonce and `createMessage` run, then Magic `personal_sign` never finishes unless `AppKitModalAccountButton` stays in the tree. The modal already listens to `onMagicRpcRequest`, but `_onMagicRequest` only handled results. Incoming requests now push `ApproveTransactionPage` the same way the account button does.

Fixes #41

## Test plan
- [x] Social (Apple) login with SIWE enabled, no hidden `AppKitModalAccountButton`
- [x] Sign completes and `/auth/v1/authenticate` / `verifyMessage` is called
- [x] Existing account-button path still works